### PR TITLE
[FIX] Incident Management installation

### DIFF
--- a/custom_addons/incident_management/data/ir_sequence_data.xml
+++ b/custom_addons/incident_management/data/ir_sequence_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Sequences for incident management -->
+        <record id="ir_sequence_incident" model="ir.sequence">
+            <field name="name">Incidents</field>
+            <field name="code">x.incident.record</field>
+            <field name="prefix">INC</field>
+            <field name="padding">4</field>
+            <field name="number_increment">1</field>
+        </record>
+    </data>
+</odoo>

--- a/custom_addons/incident_management/models/__init__.py
+++ b/custom_addons/incident_management/models/__init__.py
@@ -3,5 +3,4 @@ from . import x_inc_person
 from . import x_inc_asset
 from . import x_inc_material_spillage
 from . import x_inc_vehicle_accident
-from . import x_inc_investigation_team
 from . import x_location

--- a/custom_addons/incident_management/views/incident_management_menu.xml
+++ b/custom_addons/incident_management/views/incident_management_menu.xml
@@ -3,7 +3,6 @@
     <menuitem  id="incidents_management" name="Incidents Management">
         <menuitem id="incidents" name="Incidents">
             <menuitem id="incidents_menu_action" action="incident_record_model_action"/>
-            <menuitem id="investigation_menu_action" action="investigation_model_action" sequence="10"/>
         </menuitem>
     </menuitem>
 </odoo>


### PR DESCRIPTION
Missed to push 'ir_sequence_data.xml' file in the previous commit. Removed unused imports from init.py and unused 'menuitem'

Description of the issue/feature this PR addresses: Fix the incident_management module for successful activation

Current behavior before PR: Unable to activate the app

Desired behavior after PR is merged: Can successfully install incident management and report incidents




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
