### PR TITLE
PR for SQL constraints and option fields in tree view

### DIFF
--- a/custom_addons/incident_management/models/x_inc_material_spillage.py
+++ b/custom_addons/incident_management/models/x_inc_material_spillage.py
@@ -30,6 +30,9 @@ class IncAssetImmediateResponse(models.Model):
 
     _name = "x.inc.material.spill.immediate.response"
     _description = "Immediate response"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Immediate response must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -41,6 +44,9 @@ class IncSpillDamages(models.Model):
 
     _name = "x.inc.spill.env.impact"
     _description = "Environmental Impact"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Spill damages must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -52,6 +58,9 @@ class IncSpillUnit(models.Model):
 
     _name = "x.inc.spill.unit"
     _description = "Spill Unit"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'unit must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 

--- a/custom_addons/incident_management/models/x_inc_person.py
+++ b/custom_addons/incident_management/models/x_inc_person.py
@@ -11,6 +11,9 @@ class IncidentPersonRecord(models.Model):
 
     _name = "x.inc.person.record"
     _description = "Persons involved or victims in an Incident"
+    _sql_constraints = [
+        ('name_incident_uniq', 'unique(person_name, incident_id)', 'Person name must be unique per incident !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -76,6 +79,9 @@ class IncPersonCategory(models.Model):
 
     _name = "x.inc.person.category"
     _description = "Category of the person"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Category must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -87,6 +93,9 @@ class IncInjuryType(models.Model):
 
     _name = "x.inc.injury.type"
     _description = "Type of Injury"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Injury Type must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -98,10 +107,13 @@ class IncInjuredBodyParts(models.Model):
 
     _name = "x.inc.injured.body.parts"
     _description = "Persons involved or victims in an Incident"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Injured Body parts must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
-    name = fields.Char(string="Injure Body parts")
+    name = fields.Char(string="Injured Body Parts")
 
 
 class IncPersonImmediateResponse(models.Model):
@@ -109,6 +121,9 @@ class IncPersonImmediateResponse(models.Model):
 
     _name = "x.inc.person.immediate.response"
     _description = "Person Immediate response"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Immediate Response must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -120,7 +135,10 @@ class IncOHClassification(models.Model):
 
     _name = "x.inc.person.oh.classification"
     _description = "OH Incident classification"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'OH Incident classification must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
-    name = fields.Char(string="OH Incident classification")
+    name = fields.Char(string="OH Incident Classification")

--- a/custom_addons/incident_management/models/x_inc_vehicle_accident.py
+++ b/custom_addons/incident_management/models/x_inc_vehicle_accident.py
@@ -25,6 +25,9 @@ class IncMVAImmediateAction(models.Model):
 
     _name = "x.inc.mva.immediate.action"
     _description = "Immediate Action"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Immediate Action must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -36,6 +39,9 @@ class IncMVAClassification(models.Model):
 
     _name = "x.inc.mva.classification"
     _description = "MVA Classification"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'MVA Classification must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -47,6 +53,9 @@ class IncMVADamage(models.Model):
 
     _name = "x.inc.mva.damage"
     _description = "MVA Damage"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'MVA Damage must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 

--- a/custom_addons/incident_management/models/x_incident_record.py
+++ b/custom_addons/incident_management/models/x_incident_record.py
@@ -9,6 +9,9 @@ class IncidentRecord(models.Model):
     _name = "x.incident.record"
     _description = "To Report Incidents"
     _order = "location"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Incident Id must be unique !'),
+    ]
 
     # ---------------------------------------- CRUD METHODS ---------------------------------------
 
@@ -57,6 +60,9 @@ class IncidentType(models.Model):
 
     _name = "x.inc.type"
     _description = "Incident Type"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Incident type must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 
@@ -68,6 +74,9 @@ class IncidentShift(models.Model):
 
     _name = "x.inc.shift"
     _description = "Working Shift"
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Shift must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
 

--- a/custom_addons/incident_management/models/x_location.py
+++ b/custom_addons/incident_management/models/x_location.py
@@ -14,6 +14,9 @@ class Location(models.Model):
     _rec_name = 'name'
     _rec_names_search = ['name']
     _check_company_auto = True
+    _sql_constraints = [
+        ('name_uniq', 'unique(name,location_id)', 'Location name and it\'s parent must be unique !'),
+    ]
 
     # --------------------------------------- Fields Declaration ----------------------------------
     name = fields.Char('Location Name', required=True)

--- a/custom_addons/incident_management/views/inc_person_views.xml
+++ b/custom_addons/incident_management/views/inc_person_views.xml
@@ -6,26 +6,21 @@
         <field name="arch" type="xml">
             <tree string="Person Injured or Involved"> <!--editable="bottom"> -->
                 <field name="person_name" string="Name of the Person"/>
-                <field name="employee_id"/>
+                <field name="employee_id" optional="hide"/>
                 <field name="person_category"/>
                 <field name="nationality"/>
-                <field name="age"/>
-                <field name="experience"/>
-                <field name="job_title"/>
+                <field name="age" optional="hide"/>
+                <field name="experience" optional="hide"/>
+                <field name="job_title" optional="hide"/>
                 <field name="involved_victim"/>
-                <field name="person_category"/>
                 <field name="person_task"/>
-                <field name="person_employer"/>
+                <field name="person_employer" optional="hide"/>
                 <field name="oh_incident_classification"/>
                 <field name="incident_injured_body_parts"/>
                 <field name="incident_type_of_illness"/>
-                <field name="involved_victim"/>
                 <field name="immediate_response"/>
-                <field name="person_employer"/>
-                <field name="visited_hospital"/>
-                <field name="person_days_off"/>
-
-
+                <field name="visited_hospital" optional="hide"/>
+                <field name="person_days_off" optional="hide"/>
             </tree>
 
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Unique constraints added for LOV and optional fields tree view

Current behavior before PR: Duplicate records can be added to LOV and poor readability in tree view for people tab in incidents

Desired behavior after PR is merged: Unique records for LOVs and better readability as optional fields are hidden and can be added when required




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
