### PR TITLE
[FIX] Changes to Corrective action & Location LOV

### DIFF
--- a/custom_addons/incident_management/__manifest__.py
+++ b/custom_addons/incident_management/__manifest__.py
@@ -41,6 +41,11 @@
         'data/x_inc_env_classification_data.xml',
         'data/x_inc_env_impact_data.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'incident_management/static/src/scss/custom_style.scss',
+        ],
+    },
     'installable': True,
     'application': True,
     'license': 'LGPL-3',

--- a/custom_addons/incident_management/data/mail_template_data.xml
+++ b/custom_addons/incident_management/data/mail_template_data.xml
@@ -52,5 +52,58 @@
                 </div>
             </field>
         </record>
+         <record id="email_template_corrective_action" model="mail.template">
+            <field name="name">Investigation - Corrective Action</field>
+            <field name="model_id"
+                   ref="incident_management.model_x_inc_inv_corrective_actions"/>
+            <field name="email_from">ramya.guptha@tisys.co.in</field>
+            <field name="email_to">
+                {{object.investigation_id.incident_id.location.location_manager.email}},{{object.investigation_id.incident_id.location.location_alternate_1.email}},{{object.investigation_id.incident_id.location.location_alternate_1.email}}
+            </field>
+            <field name="subject">Assigned - Corrective Action for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <div style="margin: 0px; padding: 0px;">
+                        <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                            Dear Team,
+                            <br/>
+                            <br/>
+                            <p>An Investigation
+                                <t t-out="object.investigation_id.name"/>
+                                for incident <t t-out="object.investigation_id.name"/> with the following details has been created:
+                                <ul>
+                                    <li>
+                                        <strong>Primary Root Cause</strong>
+                                        <t t-out="object.primary_root_cause_id.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Secondary Root Cause</strong>
+                                        <t t-foreach="object.secondary_root_cause_ids" t-as="secondary_rc_id">
+                                            <t t-out="secondary_rc_id.name"/> <!-- Assuming 'name' is a field in the related model -->
+                                        </t>
+                                    </li>
+                                    <li>
+                                        <strong>Action Type</strong>
+                                        <t t-out="object.action_type.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Hierarchy of control</strong>
+                                        <t t-out="object.hierarchy_of_control.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Action Party</strong>
+                                        <t t-out="object.action_party.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Target Date</strong>
+                                        <t t-out="object.target_date"/>
+                                    </li>
+                                </ul>
+                            </p>
+                        </p>
+                    </div>
+                </div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/custom_addons/incident_management/static/src/scss/custom_style.scss
+++ b/custom_addons/incident_management/static/src/scss/custom_style.scss
@@ -1,0 +1,86 @@
+.o_input {
+    border: solid 1px #ced4da !important;
+    color: #495057 !important;
+}
+.o_form_view:not(.o_field_highlight) {
+    .o_field_many2one_selection {
+        .o_external_button, .o_dropdown_button {
+            visibility: visible;
+        }
+
+        &:hover, &:focus-within {
+            .o_external_button, .o_dropdown_button {
+                visibility: visible;
+            }
+        }
+    }
+}
+
+.o_form_view {
+    .o_group, .o_inner_group {
+        .o_field_tags {
+            width: 100%;
+        }
+    }
+
+    &:not(.o_field_highlight) {
+        .o_field_many2many_selection {
+            .o_dropdown_button {
+                visibility: visible;
+            }
+
+            &:hover, &:focus-within {
+                .o_dropdown_button {
+                    visibility: visible;
+                }
+            }
+        }
+    }
+}
+
+
+.o_field_widget {
+    // Default display and alignment of widget and internal <input/>
+    text-align: inherit;
+    display: inline-block;
+
+    textarea.o_input,
+    input.o_input {
+        display: inline-block;
+        text-align: inherit;
+    }
+
+    // Dropdowns inputs
+    .o_input_dropdown, .o_datepicker {
+        .o_input, > input {
+            padding-right: ($caret-width * 2.5) + $o-input-padding-x;
+        }
+
+        .o_dropdown_button, .o_datepicker_button {
+            @include o-position-absolute($o-input-padding-y, $o-input-padding-x, $input-border-width);
+            pointer-events: none;
+            visibility: visible;
+
+            &:after {
+                @include o-caret-down;
+            }
+        }
+    }
+ }
+body, p, h1, h2, h3 {
+    font-family: "Calibri Light", sans-serif;
+}
+
+.nav-tabs {
+  .nav-link.active,
+  .nav-item.show .nav-link {
+    color: #ffffff;
+    background-color: $o-community-color;
+    border-color: $nav-tabs-link-active-border-color;
+  }
+
+}
+
+.o_notebook {
+    --notebook-link-border-color: #{$gray-200};
+}

--- a/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
+++ b/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
@@ -6,15 +6,17 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="investigation_id" default="context.get('default_investigation_id', False)"/>
-                        <field name="primary_root_cause" default="context.get('default_primary_root_cause_id', False)" />
-                        <field name="secondary_root_cause"/>
+                        <field name="investigation_id"/>
+                        <field name="primary_root_cause_id"/>
+                        <field name="secondary_root_cause_ids" widget="many2many_tags"/>
                         <field name="action_type"/>
                         <field name="hierarchy_of_control"/>
                         <field name="action_party"/>
+                        <field name="proposed_action"/>
                         <field name="target_date"/>
                         <field name="action_status"/>
                         <field name="remarks"/>
+                        <field name="attachment_id" widget="pdf_viewer"/>
                         <button name="review_action" type="object" string="Review"/>
                     </group>
                 </sheet>
@@ -25,17 +27,19 @@
         <field name="name">x.inc.inv.corrective.actions.tree</field>
         <field name="model">x.inc.inv.corrective.actions</field>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <tree>
                 <field name="id" string="Action Number"/>
-                <field name="primary_root_cause"/>
-                <field name="secondary_root_cause"/>
+                <field name="primary_root_cause_id"/>
+                <field name="secondary_root_cause_ids" widget="many2many_tags"/>
                 <field name="action_type"/>
                 <field name="hierarchy_of_control"/>
+                <field name="proposed_action"/>
                 <field name="action_party"/>
                 <field name="target_date"/>
                 <field name="action_status"/>
                 <field name="remarks"/>
-                <button name="review_action" type="object" string="Review"/>
+                <field name="attachment_id"/>
+                <button name="review_action" type="object" string="Review" class="btn-primary"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/inc_lov_views.xml
+++ b/custom_addons/incident_management/views/inc_lov_views.xml
@@ -37,8 +37,6 @@
                 <field name="active"/>
                 <field name="usage"/>
                 <field name="location_id"/>
-                <field name="child_ids"/>
-                <field name="child_internal_location_ids"/>
                 <field name="company_id"/>
                 <field name="location_manager"/>
                 <field name="location_alternate_1"/>
@@ -51,8 +49,26 @@
         <field name="name">Location of Incident</field>
         <field name="res_model">x.location</field>
         <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="location_tree_view"/>
-        <field name="context">{'create': False}</field>
+    </record>
+    <record id="location_view_form" model="ir.ui.view">
+        <field name="name">x.location.form</field>
+        <field name="model">x.location</field>
+        <field name="arch" type="xml">
+            <form name="Location Details">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="active"/>
+                        <field name="usage"/>
+                        <field name="location_id"/>
+                        <field name="company_id"/>
+                        <field name="location_manager"/>
+                        <field name="location_alternate_1"/>
+                        <field name="location_alternate_2"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
     </record>
     <record id="person_category_action" model="ir.actions.act_window">
         <field name="name">Person Category</field>


### PR DESCRIPTION
Changes to corrective action,
- Pass the Primary & secondary root cause object reference to corresponding corrective action filed
- Email sent to Zone manager when corrective action is created for an RC
Changes to Location -
- Form view created without child_ids

Description of the issue/feature this PR addresses: CHanges to Location LOV and Corrective Actions 

Current behavior before PR: Can't create a new location in Master Configuration. The Primary & secondary root cause were text field in corrective action. No email sent to Location in charge on corrective  action creation

Desired behavior after PR is merged:- Pass the Primary & secondary root cause object reference to corresponding corrective action filed. Email sent to Zone manager when corrective action is created for an RC. Can create new location from master configuration



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
