### PR TITLE
[FIX] Form view for Environmental and Data files had been added

### DIFF
--- a/custom_addons/incident_management/__manifest__.py
+++ b/custom_addons/incident_management/__manifest__.py
@@ -45,6 +45,7 @@
         'data/x_inc_oh_severity_consequence_data.xml',
         'data/x_inc_env_severity_classification_data.xml',
         'data/x_inc_env_severity_consequence_data.xml',
+        'data/x_inc_severity_classification_data.xml',
 
     ],
     'assets': {

--- a/custom_addons/incident_management/data/x_inc_severity_classification_data.xml
+++ b/custom_addons/incident_management/data/x_inc_severity_classification_data.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <data noupdate="1">
+        <record id="sev1" model="x.inc.severity">
+            <field name="name">Class A</field>
+        </record>
+        <record id="sev2" model="x.inc.severity">
+            <field name="name">Class B</field>
+        </record>
+        <record id="sev3" model="x.inc.severity">
+            <field name="name">Class C</field>
+        </record>
+        <record id="sev4" model="x.inc.severity">
+            <field name="name">Class D</field>
+        </record>
+    </data>
+</odoo>

--- a/custom_addons/incident_management/models/x_inc_material_spillage.py
+++ b/custom_addons/incident_management/models/x_inc_material_spillage.py
@@ -11,10 +11,9 @@ class IncidentMaterialSpillageRecord(models.Model):
     _description = "Oil, Paint, Chemical Spillage, Environmental Incidents or  incidents"
 
     # --------------------------------------- Fields Declaration ----------------------------------
-
-    incident_id = fields.Many2one('x.incident.record', required=True)
-    person_reported = fields.Many2one("hr.employee", string="person_reported", required=True)
     id_number = fields.Integer(related="person_reported.id", string="ID Number")
+    person_reported = fields.Many2one("hr.employee", string="Person Reported", required=True)
+    incident_id = fields.Many2one('x.incident.record', required=True)
     task = fields.Text(string="Task being done at the time of incident")
     job_title = fields.Char(related='person_reported.job_id.name', string="Job Title")
     location = fields.Many2one("x.location", string="Incident Location")
@@ -24,9 +23,9 @@ class IncidentMaterialSpillageRecord(models.Model):
     env_impact = fields.Many2one('x.inc.spill.env.impact')
     immediate_response = fields.Many2one("x.inc.material.spill.immediate.response")
     env_severity_classification = fields.Many2one("x.inc.env.severity.classification",
-                                                  string="Severity Classification (ENV)", required=True)
+                                                  string="Severity Classification", required=True)
     env_severity_consequence = fields.Many2one("x.inc.env.severity.consequence",
-                                               string="Severity Consequence (ENV)", required=True)
+                                               string="Severity Consequence", required=True)
 
 
 class IncAssetImmediateResponse(models.Model):

--- a/custom_addons/incident_management/models/x_inc_person.py
+++ b/custom_addons/incident_management/models/x_inc_person.py
@@ -42,9 +42,9 @@ class IncidentPersonRecord(models.Model):
     oh_incident_classification = fields.Many2one("x.inc.oh.classification", string="OH Incident Classification",
                                                  required=True)
     oh_severity_classification = fields.Many2one("x.inc.oh.severity.classification",
-                                                 string="Severity Classification (OH)", required=True)
+                                                 string="Severity Classification", required=True)
     oh_severity_consequence = fields.Many2one("x.inc.oh.severity.consequence",
-                                              string="Severity Consequence (OH)", required=True)
+                                              string="Severity Consequence", required=True)
     location = fields.Many2one("x.location", string="Incident Location")
     experience = fields.Integer(string="Experience")
 

--- a/custom_addons/incident_management/models/x_incident_record.py
+++ b/custom_addons/incident_management/models/x_incident_record.py
@@ -36,7 +36,7 @@ class IncidentRecord(models.Model):
     notified_by = fields.Many2one('res.users', string="Notified By", default=lambda self: self.env.user)
     notified_by_id = fields.Integer(related="notified_by.id", string="Notified By ID")
     notified_by_type = fields.Selection(related="notified_by.employee_type")
-    severity = fields.Many2one("x.inc.severity", string="Severity Classification")
+    severity = fields.Many2one("x.inc.severity", string="Severity Classification", required=True)
 
     incident_person_ids = fields.One2many(
         'x.inc.person.record', 'incident_id', string='People'
@@ -68,7 +68,6 @@ class IncidentRecord(models.Model):
         mail_template.send_mail(self.id, force_send=True)
 
     def assign_team(self):
-
         return {
             'name': 'Investigation Team',
             'res_model': 'x.inc.investigation',
@@ -82,6 +81,8 @@ class IncidentRecord(models.Model):
 
         }
 
+    def save(self):
+        return True
 
 
 class IncidentType(models.Model):
@@ -124,3 +125,15 @@ class IncSeverity(models.Model):
     # --------------------------------------- Fields Declaration ----------------------------------
 
     name = fields.Char(string="Severity Classification")
+    notification = fields.One2many('x.inc.notification', 'severity', string='Notification Team')
+
+
+class NotificationTeam(models.Model):
+    # ---------------------------------------- Private Attributes ---------------------------------
+
+    _name = 'x.inc.notification'
+    _description = 'Notification Team'
+
+    # --------------------------------------- Fields Declaration ----------------------------------
+    severity = fields.Many2one("x.inc.severity", string="Severity Classification", required=True)
+    officer = fields.Many2one('res.users', string="Officer", required=True)

--- a/custom_addons/incident_management/security/ir.model.access.csv
+++ b/custom_addons/incident_management/security/ir.model.access.csv
@@ -34,7 +34,7 @@ access_x_inc_inv_corrective_actions,access_x_inc_inv_corrective_actions,model_x_
 access_x_inc_inv_ca_action_type,access_x_inc_inv_ca_action_type,model_x_inc_inv_ca_action_type,base.group_user,1,1,1,1
 access_x_inc_inv_ca_hierarchy_control,access_x_inc_inv_ca_hierarchy_control,model_x_inc_inv_ca_hierarchy_control,base.group_user,1,1,1,1
 access_x_inc_inv_action_review,access_x_inc_inv_action_review,model_x_inc_inv_action_review,base.group_user,1,1,1,1
-
+access_x_inc_notification,access_x_inc_notification,model_x_inc_notification,base.group_user,1,1,1,1
 
 
 

--- a/custom_addons/incident_management/views/inc_asset_views.xml
+++ b/custom_addons/incident_management/views/inc_asset_views.xml
@@ -6,10 +6,10 @@
             <tree string="Asset Damages" editable="bottom">
                 <field name="id"/>
                 <field name="asset_id"/>
-                <field name="asset_title"/>
+                <field name="asset_title" options="{'no_create': True, 'no_create_edit':True}"/>
                 <field name="asset_type"/>
                 <field name="description"/>
-                <field name="immediate_response"/>
+                <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True}"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
+++ b/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
@@ -36,11 +36,11 @@
                 <field name="proposed_action"/>
                 <field name="action_party"/>
                 <field name="target_date"/>
-                <field name="action_status"/>
                 <field name="remarks"/>
                 <field name="attachment_id"/>
                 <button name="review_action" type="object" string="Review" class="btn-primary"/>
             </tree>
         </field>
     </record>
+
 </odoo>

--- a/custom_addons/incident_management/views/inc_investigation_people_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_people_views.xml
@@ -40,7 +40,7 @@
                                    attrs="{'readonly': [('selected_category', '!=', 'Contractor')]}"/>
                             <field name="relation_to_incident"/>
                         </group>
-                        <group>
+                        <group colspan="2">
                             <field name="details_of_interview"/>
                             <field name="remarks"/>
                         </group>

--- a/custom_addons/incident_management/views/inc_lov_views.xml
+++ b/custom_addons/incident_management/views/inc_lov_views.xml
@@ -13,6 +13,23 @@
             </tree>
         </field>
     </record>
+    <record id="severity_action" model="ir.actions.act_window">
+        <field name="name">Severity Classification</field>
+        <field name="res_model">x.inc.severity</field>
+        <field name="view_mode">tree</field>
+    </record>
+
+    <record id="severity_tree_view" model="ir.ui.view">
+        <field name="name">Severity Classification</field>
+        <field name="model">x.inc.severity</field>
+        <field name="arch" type="xml">
+            <tree string="Severity Classification" editable="bottom">
+                <field name="name"/>
+                <field name="notification"/>
+            </tree>
+        </field>
+    </record>
+
     <record id="incident_type_action" model="ir.actions.act_window">
         <field name="name">Incident Type</field>
         <field name="res_model">x.inc.type</field>

--- a/custom_addons/incident_management/views/inc_person_views.xml
+++ b/custom_addons/incident_management/views/inc_person_views.xml
@@ -8,7 +8,7 @@
                 <field name="person_name" string="Name of the Person"/>
                 <field name="employee_id" optional="hide"/>
                 <field name="person_category"/>
-                <field name="nationality"/>
+                <field name="nationality" optional="1"/>
                 <field name="age" optional="hide"/>
                 <field name="experience" optional="hide"/>
                 <field name="job_title" optional="hide"/>
@@ -18,8 +18,10 @@
                 <field name="oh_incident_classification"/>
                 <field name="oh_severity_classification"/>
                 <field name="oh_severity_consequence"/>
-                <field name="incident_injured_body_parts" widget="many2many_tags"/>
-                <field name="incident_type_of_illness" widget="many2many_tags"/>
+                <field name="incident_injured_body_parts" widget="many2many_tags"
+                       options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="incident_type_of_illness" widget="many2many_tags"
+                       options="{'no_create': True, 'no_create_edit':True}"/>
                 <field name="immediate_response"/>
                 <field name="visited_hospital" optional="hide"/>
                 <field name="person_days_off" optional="hide"/>
@@ -50,10 +52,11 @@
                         <group>
                             <field name="person_task"/>
                             <field name="immediate_response"
-                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
+                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
-                            <field name="nationality"/>
+                            <field name="nationality" options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="age" readonly="False"/>
                         </group>
                         <group>

--- a/custom_addons/incident_management/views/inc_spills_views.xml
+++ b/custom_addons/incident_management/views/inc_spills_views.xml
@@ -3,20 +3,53 @@
         <field name="name">inc.spill.tree</field>
         <field name="model">x.inc.material.spill.record</field>
         <field name="arch" type="xml">
-            <tree string="Spill" editable="bottom">
-                <field name="person_reported"/>
+            <tree string="Spill">
                 <field name="id_number"/>
-                <field name="task"/>
-                <field name="job_title"/>
-                <field name="location"/>
-                <field name="env_incident_classification"/>
-                <field name="env_severity_classification"/>
-                <field name="env_severity_consequence"/>
-                <field name="qty"/>
-                <field name="unit"/>
-                <field name="env_impact"/>
-                <field name="immediate_response"/>
+                <field name="person_reported" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="task" optional="1"/>
+                <field name="job_title" optional="1"/>
+                <field name="location" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="env_incident_classification" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="env_severity_classification" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="env_severity_consequence" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="qty" optional="1"/>
+                <field name="unit" optional="1" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="env_impact" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True}"/>
             </tree>
         </field>
     </record>
+    <record id="inc_spill_view_form" model="ir.ui.view">
+        <field name="name">inc.spill.form</field>
+        <field name="model">x.inc.material.spill.record</field>
+        <field name="arch" type="xml">
+            <form name="Spill">
+                <sheet>
+                    <group col="2">
+
+                        <group>
+                            <field name="person_reported" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="id_number"/>
+                            <field name="task"/>
+                            <field name="job_title"/>
+                            <field name="location" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="qty"/>
+                        </group>
+                        <group>
+                            <field name="unit" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="env_incident_classification"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="env_severity_classification"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="env_severity_consequence"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="env_impact" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True}"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
 </odoo>
+

--- a/custom_addons/incident_management/views/incident_management_menu.xml
+++ b/custom_addons/incident_management/views/incident_management_menu.xml
@@ -2,15 +2,16 @@
 <odoo>
     <menuitem id="incidents_management" name="Incidents Management">
         <menuitem id="incidents" name="Incidents">
-            <menuitem id="incidents_menu_action" action="incident_record_model_action"/>
+            <menuitem id="incidents_menu_action" action="incident_record_model_action" sequence="1"/>
         </menuitem>
         <menuitem id="investigation" name="Investigation">
-            <menuitem id="investigation_menu_action" action="investigation_model_action"/>
+            <menuitem id="investigation_menu_action" action="investigation_model_action" sequence="1"/>
         </menuitem>
         <menuitem id="settings" name="Settings">
             <menuitem id="shift_menu_action" action="shift_action" sequence="1"/>
             <menuitem id="incident_type_menu_action" action="incident_type_action" sequence="2"/>
             <menuitem id="location_menu_action" action="location_action" sequence="3"/>
+            <menuitem id="severity_menu_action" action="severity_action" sequence="3"/>
             <menuitem id="person_category_menu_action" action="person_category_action" sequence="4"/>
             <menuitem id="person_immediate_response_menu_action" action="person_immediate_response_action"
                       sequence="5"/>
@@ -36,8 +37,6 @@
             <menuitem id="secondary_root_causes_menu_action" action="secondary_root_causes_action" sequence="20"/>
             <menuitem id="action_type_menu_action" action="action_type_action" sequence="21"/>
             <menuitem id="hierarchy_control_menu_action" action="hierarchy_control_action" sequence="22"/>
-
-
         </menuitem>
     </menuitem>
 </odoo>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -24,7 +24,9 @@
             <form name="Incident Details">
                 <header>
                     <button name="assign_team" type="object" string="Assign Team" states="new"/>
-                    <field name="state" widget="statusbar" statusbar_visible="new,investigation_assigned,investigation_in_progress,action_review,closed"/>
+                    <button string="Save" type="object" name="save"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="new,investigation_assigned,investigation_in_progress,action_review,closed"/>
                 </header>
                 <sheet>
                     <h1>
@@ -34,11 +36,14 @@
                         <group>
                             <field name="inc_date_time"/>
                             <field name="inc_reported_date"/>
+                            <field name="severity" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="shift" widget="selection"/>
-                            <field name="type" widget="many2many_tags" options="{'no_create': True, 'no_create_edit':True}"/>
-                            <field name="location"/>
+                            <field name="type" widget="many2many_tags"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="location" options="{'no_create': True, 'no_create_edit':True}"/>
+
                         </group>
                         <group>
                             <field name="notified_by"/>
@@ -52,17 +57,26 @@
                     </group>
                     <notebook>
                         <page string="People">
-                            <field name="incident_person_ids" />
+                            <field name="incident_person_ids"/>
                         </page>
                         <page string="Assets">
-                            <field name="incident_asset_ids" />
+                            <field name="incident_asset_ids"/>
                         </page>
                         <page string="Environmental">
-                            <field name="incident_spill_ids" />
+                            <field name="incident_spill_ids"/>
                         </page>
                     </notebook>
                 </sheet>
             </form>
+        </field>
+    </record>
+    <record id="notification_tree_view" model="ir.ui.view">
+        <field name="name">x.inc.notification.tree</field>
+        <field name="model">x.inc.notification</field>
+        <field name="arch" type="xml">
+            <tree string="Notification tree" editable="bottom">
+                <field name="officer"/>
+            </tree>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Form view for Environmental, Data files had been added.
Current behavior before PR:  Environmental tab in tree view only

Desired behavior after PR is merged: Environmental tab in form view, Severity Data had been added




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
