### PR TITLE
In person view align the Groups and In record add attributes

### DIFF
--- a/custom_addons/incident_management/views/inc_person_views.xml
+++ b/custom_addons/incident_management/views/inc_person_views.xml
@@ -41,35 +41,13 @@
                                    attrs="{'invisible': [('selected_category', 'not in', ('Employee','Contractor'))], 'required': [('selected_category', 'in', ('Employee','Contractor'))]}"/>
                             <field name="visitor_name"
                                    attrs="{'invisible': [('selected_category', 'not in', ('Visitor','Others'))], 'required': [('selected_category', 'in', ('Visitor','Others'))]}"/>
-                        </group>
-                        <group>
-                            <field name="involved_victim"/>
-                            <field name="employee_id"
-                                   attrs="{'invisible': [('selected_category', 'not in', ('Employee','Contractor'))]}"/>
-                            <field name="experience"/>
-                        </group>
-                        <group>
                             <field name="person_task"/>
                             <field name="immediate_response"
                                    attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
-                        </group>
-                        <group>
-                            <field name="nationality" options="{'no_create': True, 'no_create_edit':True}"/>
-                            <field name="age" readonly="False"/>
-                        </group>
-                        <group>
                             <field name="job_title"/>
                             <field name="person_employer"
                                    attrs="{'readonly': [('selected_category', '!=', 'Contractor')]}"/>
-                        </group>
-                        <group>
-                            <field name="visited_hospital"
-                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
-                            <field name="person_days_off"
-                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
-                        </group>
-                        <group>
                             <field name="incident_type_of_illness"
                                    attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))], 'required': [('involved_victim', 'in', ('victim', 'both'))]}"
                                    widget="many2many_tags" options="{'no_create': True, 'no_create_edit':True}"/>
@@ -78,11 +56,21 @@
                                    widget="many2many_tags" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
+                            <field name="involved_victim"/>
+                            <field name="employee_id"
+                                   attrs="{'invisible': [('selected_category', 'not in', ('Employee','Contractor'))]}"/>
+                            <field name="experience"/>
+                            <field name="nationality" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="age" readonly="False"/>
+                            <field name="visited_hospital"
+                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
+                            <field name="person_days_off"
+                                   attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
                             <field name="oh_incident_classification" widget="selection"/>
                             <field name="oh_severity_consequence" widget="selection"/>
+                            <field name="selected_category" invisible="1"/>
+                            <field name="person_name" invisible="1"/>
                         </group>
-                        <field name="selected_category" invisible="1"/>
-                        <field name="person_name" invisible="1"/>
                     </group>
                 </sheet>
             </form>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -56,10 +56,10 @@
                         <page string="People">
                             <field name="incident_person_ids"/>
                         </page>
-                        <page string="Assets">
+                        <page string="Assets" attrs="{'invisible': [('type', 'not in', (3))]}">
                             <field name="incident_asset_ids"/>
                         </page>
-                        <page string="Environmental">
+                        <page string="Environmental" attrs="{'invisible': [('type', 'not in', (2))]}">
                             <field name="incident_spill_ids"/>
                         </page>
                     </notebook>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In person view align the Groups and In record add attributes in Asset and Environment

Current behavior before PR: Unaligned groups

Desired behavior after PR is merged: Modified as order




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
