### PR TITLE
[FIX] Alignment changes in Investigation model

### DIFF
--- a/custom_addons/incident_management/models/x_inc_investigation.py
+++ b/custom_addons/incident_management/models/x_inc_investigation.py
@@ -158,23 +158,20 @@ class IncidentPeopleInterviewed(models.Model):
         string='Q 8: Did the victim or person involved have a previous history of incidents?'
     )
 
+    @api.depends('person_category', 'employee', 'visitor_name')
+    def _compute_name(self):
+        for person in self:
+            if person.person_category.name in ("Employee", "Contractor") and person.employee:
+                person.person_name = person.employee.name
+            elif person.person_category.name in ("Visitor", "Others") and person.visitor_name:
+                person.person_name = person.visitor_name
+            else:
+                person.person_name = False
 
-@api.depends('person_category', 'employee', 'visitor_name')
-def _compute_name(self):
-    for person in self:
-        if person.person_category.name in ("Employee", "Contractor") and person.employee:
-            person.person_name = person.employee.name
-            # person.nationality = person.employee.country_id
-        elif person.person_category.name in ("Visitor", "Others") and person.visitor_name:
-            person.person_name = person.visitor_name
-        else:
-            person.person_name = False
-
-
-@api.depends('person_category')
-def _compute_selected_category(self):
-    for record in self:
-        record.selected_category = record.person_category.name
+    @api.depends('person_category')
+    def _compute_selected_category(self):
+        for record in self:
+            record.selected_category = record.person_category.name
 
 
 class IncidentConsequences(models.Model):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In Incident People Interviewed @api alignment had been changed

Current behavior before PR: Employee name field not viewed

Desired behavior after PR is merged: Employee name field viewed




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
