### PR TITLE
[FIX] Background colour for text fields and set Incident severity classification

### DIFF
--- a/custom_addons/incident_management/models/x_inc_inv_action_review.py
+++ b/custom_addons/incident_management/models/x_inc_inv_action_review.py
@@ -68,6 +68,7 @@ class ActionReview(models.Model):
 
     def start_review(self):
         self.state = 'review'
+        self.investigation_id.incident_id.write({'state': 'action_review'})
 
     def action_confirm(self):
         self.write({'state': 'followup'})
@@ -104,6 +105,7 @@ class ActionReview(models.Model):
                             all_closed = False
             if all_closed:
                 investigation.state = 'closed'
+                investigation.incident_id.state = 'closed'
 
     def action_resubmit_for_review(self):
         self.write({'state': 'review'})

--- a/custom_addons/incident_management/models/x_inc_investigation.py
+++ b/custom_addons/incident_management/models/x_inc_investigation.py
@@ -29,7 +29,7 @@ class IncInvestigation(models.Model):
         string="Investigation", readonly=True, default='New')
     incident_id = fields.Many2one("x.incident.record", string="Incident Id")
     description = fields.Html(related="incident_id.description")
-    # description = fields.Html(related="incident_id.description")
+    severity = fields.Many2one("x.inc.severity", string="Severity Classification", required=False)
     # Investigation Team Details
     hse_officer = fields.Many2one("hr.employee", string="HSE Officer", required=True)
     hse_officer_id = fields.Integer(related="hse_officer.id", string="ID Number")
@@ -86,6 +86,10 @@ class IncInvestigation(models.Model):
             attachments = self.env['ir.attachment'].search([('res_model', '=', 'x.inc.inv.corrective.actions'),
                                                             ('res_id', 'in', investigation.corrective_actions_ids.ids)])
             investigation.corrective_action_attachments = [(6, 0, attachments.ids)]
+
+    @api.onchange('severity')
+    def _update_inc_severity_classification(self):
+        self.incident_id.severity = self.severity
 
 
 class InvestigationTeam(models.Model):

--- a/custom_addons/incident_management/static/src/scss/custom_style.scss
+++ b/custom_addons/incident_management/static/src/scss/custom_style.scss
@@ -1,6 +1,7 @@
 .o_input {
     border: solid 1px #ced4da !important;
     color: #495057 !important;
+    background-color: #E9ECEF;
 }
 .o_form_view:not(.o_field_highlight) {
     .o_field_many2one_selection {

--- a/custom_addons/incident_management/views/inc_investigation_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_views.xml
@@ -33,6 +33,7 @@
                     <group>
                         <field name="incident_id" default="context.get('default_incident_id', False)"/>
                         <field name="description"/>
+                        <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')]}" options="{'no_create': True, 'no_create_edit': True}"/>
                     </group>
                     <notebook>
                         <page string="Investigation Team">

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -35,7 +35,7 @@
                         <group>
                             <field name="inc_date_time"/>
                             <field name="inc_reported_date"/>
-                            <field name="severity" invisible="1" options="{'no_create': True, 'no_create_edit': True}"/>
+                            <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')]}" options="{'no_create': True, 'no_create_edit': True}"/>
                         </group>
                         <group>
                             <field name="shift" widget="selection"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Request to change the text field background, update of severity classification on Incident closure

Current behavior before PR:  No background for the text fields and severity classification was not being set

Desired behavior after PR is merged:
When investigation is closed, user can update the incident severity from Investigation or Incident form. Fields are displayed with grey background



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
