### PR TITLE
[FIX] Severity Classification , Email alerts, Company Metrics

### DIFF
--- a/custom_addons/incident_management/data/mail_template_data.xml
+++ b/custom_addons/incident_management/data/mail_template_data.xml
@@ -6,7 +6,7 @@
                    ref="incident_management.model_x_incident_record"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.location.location_manager.work_email}},{{object.location.location_alternate_1.work_email}},{{object.location.location_alternate_1.work_email}}
+                {{object.location.location_manager.work_email}},{{object.location.location_alternate_1.work_email}},{{object.location.location_alternate_2.work_email}}
             </field>
             <field name="subject">{{object.name}}</field>
             <field name="body_html" type="html">
@@ -58,7 +58,7 @@
                    ref="incident_management.model_x_inc_inv_corrective_actions"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}}
+                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
             </field>
             <field name="subject">Assigned - Corrective Action for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -164,13 +164,70 @@
                 </div>
             </field>
         </record>
+        <record id="email_template_action_review" model="mail.template">
+            <field name="name">Investigation - Start Action Review</field>
+            <field name="model_id"
+                   ref="incident_management.model_x_inc_inv_action_review"/>
+            <field name="email_from">aicomsy.alerts@gmail.com</field>
+            <field name="email_to">
+                {{object.investigation_id.hse_officer.work_email}},{{object.investigation_id.field_executive.work_email}},{{object.investigation_id.hr_administration.work_email}}
+            </field>
+            <field name="subject">Start - Action Review for {{object.investigation_id.name}} - {{object.corrective_action_id.primary_root_cause_id.name}}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <div style="margin: 0px; padding: 0px;">
+                        <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                            Dear Team,
+                            <br/>
+                            <br/>
+                            <p>An Investigation
+                                <t t-out="object.investigation_id.name"/>
+                                for incident
+                                <t t-out="object.investigation_id.incident_id.name"/>
+                                with the following details has been completed:
+                                <ul>
+                                    <li>
+                                        <strong>Primary Root Cause</strong>
+                                        <t t-out="object.corrective_action_id.primary_root_cause_id.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Secondary Root Cause</strong>
+                                        <t t-foreach="object.corrective_action_id.secondary_root_cause_ids"
+                                           t-as="secondary_rc_id">
+                                            <t t-out="secondary_rc_id.name"/> <!-- Assuming 'name' is a field in the related model -->
+                                        </t>
+                                    </li>
+                                    <li>
+                                        <strong>Action Type</strong>
+                                        <t t-out="object.corrective_action_id.action_type.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Hierarchy of control</strong>
+                                        <t t-out="object.corrective_action_id.hierarchy_of_control.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Action Party</strong>
+                                        <t t-out="object.corrective_action_id.action_party.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Target Date</strong>
+                                        <t t-out="object.corrective_action_id.target_date"/>
+                                    </li>
+                                </ul>
+                                Kindly review the same.
+                            </p>
+                        </p>
+                    </div>
+                </div>
+            </field>
+        </record>
         <record id="email_template_return_to_corrective_action" model="mail.template">
             <field name="name">Investigation - Corrective Action</field>
             <field name="model_id"
                    ref="incident_management.model_x_inc_inv_action_review"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.corrective_action_id.action_party.work_email}},{{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}}
+                {{object.corrective_action_id.action_party.work_email}},{{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
             </field>
             <field name="subject">Returned - Corrective Action for {{object.investigation_id.name}} - {{object.corrective_action_id.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -228,8 +285,7 @@
             <field name="email_to">
                 {{object.investigation_id.hse_officer.work_email}},{{object.investigation_id.field_executive.work_email}},{{object.investigation_id.hr_administration.work_email}}
             </field>
-            <field name="subject">Revisit Action Review - Corrective Action for {{object.investigation_id.name}} - {{object.corrective_action_id.primary_root_cause_id.name}}
-            </field>
+            <field name="subject">Revisit Action Review - Corrective Action for {{object.investigation_id.name}} - {{object.corrective_action_id.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <div style="margin: 0px; padding: 0px;">
@@ -336,6 +392,39 @@
                                         <t t-out="object.corrective_action_id.target_date"/>
                                     </li>
                                 </ul>
+                                Kindly review the same.
+                            </p>
+                        </p>
+                    </div>
+                </div>
+            </field>
+        </record>
+        <record id="email_template_incident_closure" model="mail.template">
+            <field name="name">Incident &amp; InvestigationClosure </field>
+            <field name="model_id"
+                   ref="incident_management.model_x_inc_inv_action_review"/>
+            <field name="email_from">aicomsy.alerts@gmail.com</field>
+            <field name="email_to">
+                {{object.investigation_id.hse_officer.work_email}},{{object.investigation_id.field_executive.work_email}},
+                {{object.investigation_id.hr_administration.work_email}},{{object.investigation_id.incident_id.location.location_manager.work_email}},
+                {{object.investigation_id.incident_id.location.location_alternate_1.work_email}},
+                {{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+            </field>
+            <field name="subject">Closure of  {{object.investigation_id.name}} - {{object.investigation_id.incident_id.name}}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <div style="margin: 0px; padding: 0px;">
+                        <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                            Dear Team,
+                            <br/>
+                            <br/>
+                            <p>An Investigation
+                                <t t-out="object.investigation_id.name"/>
+                                for incident
+                                <t t-out="object.investigation_id.incident_id.name"/>
+                                is closed.
+
+
                                 Kindly review the same.
                             </p>
                         </p>

--- a/custom_addons/incident_management/models/x_company_monthly_metrics.py
+++ b/custom_addons/incident_management/models/x_company_monthly_metrics.py
@@ -24,17 +24,25 @@ class MonthlyMetrics(models.Model):
         ('11', 'November'),
         ('12', 'December'),
     ]
+    name = fields.Char(string='Name', compute='_compute_name', store=True)
     month = fields.Integer(string='Month (Integer)', store=True)
     year = fields.Integer(string='Year (Integer)', store=True)
     month_selection = fields.Selection(MONTHS, string='Month')
 
     year_selection = fields.Selection(
-        [(str(year), str(year)) for year in range(1990, 2030)],
+        [(str(year), str(year)) for year in range(1990, 2050)],
         string='Year')
 
     working_days = fields.Integer(string='Working Days')
     hour_worked = fields.Float(string='Hours Worked')
     total_sales = fields.Integer(string='Total Sales')
+
+    @api.depends('month_selection', 'year_selection')
+    def _compute_name(self):
+        for record in self:
+            if record.month_selection and record.year_selection:
+                month_name = dict(record.MONTHS).get(str(record.month_selection))
+                record.name = f"{month_name} {record.year_selection}"
 
     @api.onchange('month_selection')
     def _compute_month_integer(self):
@@ -46,17 +54,3 @@ class MonthlyMetrics(models.Model):
     def _compute_year_integer(self):
         for record in self:
             record.year = int(record.year_selection)
-
-    def _compute_month(self):
-        for record in self:
-            if record.month is not None:
-                record.month_selection = str(record.month)
-            else:
-                record.month_selection = str(datetime.now().month)
-
-    def _compute_year(self):
-        for record in self:
-            if record.year is not None and record:
-                record.year_selection = str(record.year)
-            else:
-                record.year_selection = str(datetime.now().year)

--- a/custom_addons/incident_management/models/x_inc_inv_action_review.py
+++ b/custom_addons/incident_management/models/x_inc_inv_action_review.py
@@ -106,6 +106,7 @@ class ActionReview(models.Model):
             if all_closed:
                 investigation.state = 'closed'
                 investigation.incident_id.state = 'closed'
+                self._inv_inc_closure_send_email()
 
     def action_resubmit_for_review(self):
         self.write({'state': 'review'})
@@ -117,6 +118,8 @@ class ActionReview(models.Model):
 
     def action_completion_send_email(self):
         mail_template = self.env.ref('incident_management.email_template_corrective_action_completion')
+        mail_template.send_mail(self.id, force_send=True)
+        mail_template = self.env.ref('incident_management.email_template_action_review')
         mail_template.send_mail(self.id, force_send=True)
 
     def _return_to_action_party(self):
@@ -134,3 +137,7 @@ class ActionReview(models.Model):
     def action_submit_for_management_review(self):
         self.write({'state': 'management'})
         return True
+
+    def _inv_inc_closure_send_email(self):
+        mail_template = self.env.ref('incident_management.email_template_incident_closure')
+        mail_template.send_mail(self.id, force_send=True)

--- a/custom_addons/incident_management/models/x_incident_record.py
+++ b/custom_addons/incident_management/models/x_incident_record.py
@@ -135,5 +135,6 @@ class NotificationTeam(models.Model):
     _description = 'Notification Team'
 
     # --------------------------------------- Fields Declaration ----------------------------------
+    name = fields.Char(string='Employee Name', related='officer.name', readonly=True)
     severity = fields.Many2one("x.inc.severity", string="Severity Classification", required=True)
-    officer = fields.Many2one('res.users', string="Officer", required=True)
+    officer = fields.Many2one('hr.employee', string="Officer", required=True)

--- a/custom_addons/incident_management/views/inc_lov_views.xml
+++ b/custom_addons/incident_management/views/inc_lov_views.xml
@@ -16,16 +16,16 @@
     <record id="severity_action" model="ir.actions.act_window">
         <field name="name">Severity Classification</field>
         <field name="res_model">x.inc.severity</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">tree,form</field>
     </record>
 
     <record id="severity_tree_view" model="ir.ui.view">
         <field name="name">Severity Classification</field>
         <field name="model">x.inc.severity</field>
         <field name="arch" type="xml">
-            <tree string="Severity Classification" editable="bottom">
+            <tree string="Severity Classification">
                 <field name="name"/>
-                <field name="notification"/>
+                <field name="notification" widget="many2many_tags"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -35,7 +35,7 @@
                         <group>
                             <field name="inc_date_time"/>
                             <field name="inc_reported_date"/>
-                            <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')]}" options="{'no_create': True, 'no_create_edit': True}"/>
+                            <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')]}" options="{'no_create': True, 'no_create_edit': True}" readonly="True"/>
                         </group>
                         <group>
                             <field name="shift" widget="selection"/>
@@ -48,7 +48,7 @@
                             <field name="notified_by_id"/>
                             <field name="notified_by_type"/>
                         </group>
-                        <group name="Description">
+                        <group name="Description" colspan="3">
                             <field name="description" placeholder="Enter a description of the incident"/>
                         </group>
                     </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 

- Incident Description box will span 3 cols
- Notification team for each severity classification
- Email template  added for incident closure, action review closure

Current behavior before PR: Description box is small. From master configuration unable to add the notification teambased on severity. Email was not sent when incident and investigation is closed

Desired behavior after PR is merged: Th Description box will span across 3 columns. CAn configure the details of the notification team based on severity. Emails sent to HSE Officer, investigation team on incident closure.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
