### PR TITLE
[FIX] Aicomsy Base, Email Alert and security groups

### DIFF
--- a/custom_addons/aicomsy_base/__manifest__.py
+++ b/custom_addons/aicomsy_base/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Aicomsy Base',
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'security/security.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/custom_addons/aicomsy_base/security/security.xml
+++ b/custom_addons/aicomsy_base/security/security.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="aicomsy_category" model="ir.module.category">
+        <field name="name">Aicomsy</field>
+    </record>
+     <record id="aicomsy_base.access_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+    <record id="aicomsy_base.access_hse_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+    <record id="aicomsy_base.access_zonal_manager" model="res.groups">
+        <field name="name">Location Manager</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+    <record id="aicomsy_base.access_management_team" model="res.groups">
+        <field name="name">High Level Management</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+    <record id="aicomsy_base.access_administrator" model="res.groups">
+        <field name="name">Admin</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+
+</odoo>

--- a/custom_addons/incident_management/__manifest__.py
+++ b/custom_addons/incident_management/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Incident Management',
     'depends': [
-        'base', 'hr', 'maintenance',
+        'base', 'aicomsy_base', 'hr', 'maintenance',
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/custom_addons/incident_management/data/mail_template_data.xml
+++ b/custom_addons/incident_management/data/mail_template_data.xml
@@ -107,6 +107,61 @@
                 </div>
             </field>
         </record>
+        <record id="email_template_corrective_action_notify_assigner" model="mail.template">
+            <field name="name">Investigation - Corrective Action</field>
+            <field name="model_id"
+                   ref="incident_management.model_x_inc_inv_corrective_actions"/>
+            <field name="email_from">aicomsy.alerts@gmail.com</field>
+            <field name="email_to">
+                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+            </field>
+            <field name="subject">Review - Corrective Action for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
+            <field name="body_html" type="html">
+                <div style="margin: 0px; padding: 0px;">
+                    <div style="margin: 0px; padding: 0px;">
+                        <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                            Dear Team,
+                            <br/>
+                            <br/>
+                            <p>An Investigation
+                                <t t-out="object.investigation_id.name"/>
+                                for incident
+                                <t t-out="object.investigation_id.incident_id.name"/>
+                                with the following details has been sent for review by <t t-out="object.action_party.name"/>:
+                                <ul>
+                                    <li>
+                                        <strong>Primary Root Cause</strong>
+                                        <t t-out="object.primary_root_cause_id.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Secondary Root Cause</strong>
+                                        <t t-foreach="object.secondary_root_cause_ids" t-as="secondary_rc_id">
+                                            <t t-out="secondary_rc_id.name"/> <!-- Assuming 'name' is a field in the related model -->
+                                        </t>
+                                    </li>
+                                    <li>
+                                        <strong>Action Type</strong>
+                                        <t t-out="object.action_type.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Hierarchy of control</strong>
+                                        <t t-out="object.hierarchy_of_control.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Action Party</strong>
+                                        <t t-out="object.action_party.name"/>
+                                    </li>
+                                    <li>
+                                        <strong>Target Date</strong>
+                                        <t t-out="object.target_date"/>
+                                    </li>
+                                </ul>
+                            </p>
+                        </p>
+                    </div>
+                </div>
+            </field>
+        </record>
         <record id="email_template_corrective_action_completion" model="mail.template">
             <field name="name">Investigation - Corrective Action</field>
             <field name="model_id"

--- a/custom_addons/incident_management/models/x_inc_investigation.py
+++ b/custom_addons/incident_management/models/x_inc_investigation.py
@@ -360,6 +360,9 @@ class CorrectiveAction(models.Model):
 
         }
 
+    def send_zonal_review_action(self):
+        self._notify_assigner_send_email()
+
     def resend_review_action(self):
         existing_record = self.env['x.inc.inv.action.review'].search([
             ('investigation_id', '=', self.investigation_id.id),
@@ -375,6 +378,10 @@ class CorrectiveAction(models.Model):
                 'res_id': existing_record.id,
                 'target': 'new',
             }
+
+    def _notify_assigner_send_email(self):
+        mail_template = self.env.ref('incident_management.email_template_corrective_action_notify_assigner')
+        mail_template.send_mail(self.id, force_send=True)
 
 
 class ActionType(models.Model):

--- a/custom_addons/incident_management/views/inc_action_review_closure_views.xml
+++ b/custom_addons/incident_management/views/inc_action_review_closure_views.xml
@@ -10,13 +10,13 @@
         <field name="arch" type="xml">
             <form string="Action Review">
                 <header>
-                    <button name="start_review" type="object" string="Start" class="btn-primary"
+                    <button name="start_review" type="object" string="Start" class="btn-primary" groups="aicomsy_base.access_hse_manager"
                             attrs="{'invisible': [('state', '!=', 'new')]}" confirm="Are you sure you want to start the Action Review ?"/>
                     <field name="state" widget="statusbar" statusbar_visible="new,review,followup,management,closed"/>
                 </header>
                 <sheet>
                     <group>
-                        <field name="corrective_action_id"/>
+                        <field name="corrective_action_id" domain="[('id', '=', context.get('corrective_action_id', False))]"/>
                     </group>
                     <group col="2" string="Action Review">
                         <group>
@@ -35,9 +35,9 @@
                     </group>
                     <group attrs="{'invisible': [('state', 'in', ('new', 'closed'))]}">
                         <button name="action_confirm" type="object" string="Confirm" class="btn-primary"
-                                confirm="Are you sure you want to Proceed?"/>
+                                confirm="Are you sure you want to Proceed?" groups="aicomsy_base.access_hse_manager"/>
                         <button name="action_return" type="object" string="Return" class="btn-primary"
-                                confirm="Are you sure you want to submit it for Corrective Action?"/>
+                                confirm="Are you sure you want to submit it for Corrective Action?" groups="aicomsy_base.access_hse_manager"/>
                     </group>
                     <br/>
                     <group col="3" string="Followup &amp; Closure"
@@ -71,24 +71,24 @@
                         <group colspan="2">
                             <button name="action_close" colspan="2" type="object" string="Close the Review"
                                     attrs="{'readonly': [('review_by_ceo_vp_gm_required', '=', 'yes')]}"
-                                    class="btn-primary" confirm="Are you sure want  to Close the Review?"/>
+                                    class="btn-primary" confirm="Are you sure want  to Close the Review?" groups="aicomsy_base.access_hse_manager"/>
                         </group>
                         <group colspan="2">
                             <button name="action_resubmit_for_review" colspan="2" type="object"
                                     string="Resubmit for Review"
-                                    class="btn-primary" confirm="Are you sure you want to Resubmit for Review?"/>
+                                    class="btn-primary" confirm="Are you sure you want to Resubmit for Review?" groups="aicomsy_base.access_hse_manager"/>
                         </group>
                         <group colspan="2">
                             <button name="action_submit_for_management_review" colspan="2" type="object"
                                     string="Submit for Management Review"
                                     class="btn-primary"
                                     attrs="{'invisible': [('review_by_ceo_vp_gm_required', '!=', 'yes')]}"
-                                    confirm="Are you sure you want to Submit for Management Review?"/>
+                                    confirm="Are you sure you want to Submit for Management Review?" groups="aicomsy_base.access_hse_manager"/>
                         </group>
                     </group>
                     <br/>
-                    <group col="3" string="Management Review"
-                           attrs="{'invisible': [('state', 'in', ['new','review', 'followup','closed'])]}">
+                    <group col="3" string="Management Review" groups="aicomsy_base.access_management_team"
+                           attrs="{'invisible': [('state', 'in', ['new','review', 'followup'])]}">
                         <group>
                             <field name="reviewed_by_ceo_vp_gm"
                                    attrs="{'required': [('state', '=', 'management')], 'readonly': [('state', '=', 'closed')]}"/>
@@ -102,9 +102,9 @@
                                    attrs="{'required': [('state', '=', 'management')], 'readonly': [('state', '=', 'closed')]}"/>
                         </group>
                     </group>
-                    <group attrs="{'invisible': [('state', 'in', ['new','review', 'followup','closed'])]}">
+                    <group attrs="{'invisible': [('state', 'in', ['new','review', 'followup','closed'])]}" groups="aicomsy_base.access_management_team">
                         <button name="action_close" type="object" string="Close" class="btn-primary"
-                                confirm="Are you sure want to close?"/>
+                                confirm="Are you sure want to close?" />
                         <button name="action_return_further_action" type="object" string="Return for Further Action"
                                 class="btn-primary" confirm="Are you sure you want to Return for Further Action?"/>
                     </group>

--- a/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
+++ b/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
@@ -7,9 +7,11 @@
                 <header>
                     <button name="start_action" type="object" string="Start" states="new" class="btn-primary"/>
                     <button name="review_action" type="object" string="Send for Review" states="in_progress"
-                            class="btn-primary"/>
-                     <button name="resend_review_action" type="object" string="Resend for Review" states="returned"
-                            class="btn-primary"/>
+                            class="btn-primary" groups="aicomsy_base.access_zonal_manager"/>
+                    <button name="send_zonal_review_action" type="object" string="Notify Assigner" states="in_progress"
+                            class="btn-primary" groups="aicomsy_base.access_zonal_manager"/>
+                    <button name="resend_review_action" type="object" string="Resend for Review" states="returned"
+                            class="btn-primary" groups="aicomsy_base.access_zonal_manager"/>
                     <field name="state" widget="statusbar" statusbar_visible="new,in_progress,completed"/>
                 </header>
                 <sheet>

--- a/custom_addons/incident_management/views/inc_investigation_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_views.xml
@@ -23,7 +23,7 @@
             <form name="Investigation Details">
                 <header>
                     <button name="start_investigation" type="object" string="Start Investigation" states="assigned"
-                            class="btn-primary"/>
+                            class="btn-primary" groups="aicomsy_base.access_hse_manager"/>
                     <field name="state" widget="statusbar" statusbar_visible="assigned,in_progress,closed"/>
                 </header>
                 <sheet>
@@ -31,7 +31,7 @@
                         <field name="name"/>
                     </h1>
                     <group>
-                        <field name="incident_id" default="context.get('default_incident_id', False)"/>
+                        <field name="incident_id" default="context.get('default_incident_id', False)" domain="[('id', '=', context.get('default_incident_id', False))]" />
                         <field name="description"/>
                         <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')]}" options="{'no_create': True, 'no_create_edit': True}"/>
                     </group>

--- a/custom_addons/incident_management/views/inc_root_causes_views.xml
+++ b/custom_addons/incident_management/views/inc_root_causes_views.xml
@@ -13,7 +13,7 @@
                 <field name="secondary_root_cause_ids" widget='many2many_tags'
                        options="{'no_create': True, 'no_create_edit':True}"/>
                 <field name="comments"/>
-                <button name="corrective_action" type="object" string="Take Action" class="oe_highlight"/>
+                <button name="corrective_action" type="object" string="Take Action" class="oe_highlight" groups="aicomsy_base.access_zonal_manager"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/incident_management_menu.xml
+++ b/custom_addons/incident_management/views/incident_management_menu.xml
@@ -7,7 +7,7 @@
         <menuitem id="investigation" name="Investigation">
             <menuitem id="investigation_menu_action" action="investigation_model_action" sequence="1"/>
         </menuitem>
-        <menuitem id="settings" name="Settings">
+        <menuitem id="settings" name="Settings" groups="aicomsy_base.access_administrator">
             <menuitem id="shift_menu_action" action="shift_action" sequence="1"/>
             <menuitem id="incident_type_menu_action" action="incident_type_action" sequence="2"/>
             <menuitem id="location_menu_action" action="location_action" sequence="3"/>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -23,7 +23,8 @@
         <field name="arch" type="xml">
             <form name="Incident Details">
                 <header>
-                    <button name="assign_team" type="object" string="Assign Team" states="new" class="btn-primary" confirm="Are you sure to go ahead with Investigation Team Assignment? "/>
+                    <button name="assign_team" type="object" string="Assign Team" states="new" class="btn-primary"
+                            confirm="Are you sure to go ahead with Investigation Team Assignment? " groups="aicomsy_base.access_zonal_manager"/>
                     <field name="state" widget="statusbar"
                            statusbar_visible="new,investigation_assigned,investigation_in_progress,action_review,closed"/>
                 </header>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Added Aicomsy base module as a dependency for all modules to be created for Aicomsy. Security groups added for location manager, admin, HSE_Officer, higher management. Email alert changes

Current behavior before PR: Security groups are not defined so all users have complete access . Emails sent when user action_party notifies the assigner

Desired behavior after PR is merged: Few functionalities are enabled based on the group the user is assigned to. Email alerts sent to notify the assigner




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
