### PR TITLE
[FIX] Modify Save and Discard Button, Type change in Company Metrics

### DIFF
--- a/custom_addons/aicomsy_base/__manifest__.py
+++ b/custom_addons/aicomsy_base/__manifest__.py
@@ -8,6 +8,12 @@
         'security/security.xml',
         'security/ir.model.access.csv',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'aicomsy_base/static/src/*',
+        ],
+
+    },
     'installable': True,
     'license': 'LGPL-3',
 }

--- a/custom_addons/aicomsy_base/static/src/form_status_indicators.xml
+++ b/custom_addons/aicomsy_base/static/src/form_status_indicators.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="aicomsy_base.FormStatusIndicator" t-inherit="web.FormStatusIndicator" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
+            <button type="button" class="o_form_button_save btn btn-primary"
+                t-att-disabled="props.isDisabled"
+                data-hotkey="s"
+                t-on-click.stop="save"
+                data-tooltip="Save manually"
+                aria-label="Save manually">
+                Save
+            </button>
+        </xpath>
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="replace">
+            <button type="button"
+                class="o_form_button_cancel btn btn-secondary"
+                t-att-disabled="props.isDisabled"
+                data-hotkey="j"
+                t-on-click.stop="discard"
+                data-tooltip="Discard changes"
+                aria-label="Discard changes">
+                Discard
+            </button>
+        </xpath>
+    </t>
+</templates>
+

--- a/custom_addons/incident_management/models/x_company_monthly_metrics.py
+++ b/custom_addons/incident_management/models/x_company_monthly_metrics.py
@@ -35,7 +35,7 @@ class MonthlyMetrics(models.Model):
 
     working_days = fields.Integer(string='Working Days')
     hour_worked = fields.Float(string='Hours Worked')
-    total_sales = fields.Integer(string='Total Sales')
+    total_sales = fields.Float(string='Total Sales')
 
     @api.depends('month_selection', 'year_selection')
     def _compute_name(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Better look and feel for Save and Discard Button, Total_Sales should accept decimal values in Company Metrics

Current behavior before PR: Default Save and Discard Buttons are displayed. Total_Sales is stored as Integer type

Desired behavior after PR is merged: Override Default Save and Discard Button  to use regular rectangular buttons and Total_Sales in monthly metrics accepts Float type




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
