### PR TITLE
[FIX] Dashboard Filter and constraint change in ncr response

### DIFF
--- a/custom_addons/aicomsy_base/__manifest__.py
+++ b/custom_addons/aicomsy_base/__manifest__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Aicomsy Base',
+    'category': 'Aicomsy/Aicomsy',
     'depends': [
         'base', 'hr',
     ],

--- a/custom_addons/aicomsy_base/security/security.xml
+++ b/custom_addons/aicomsy_base/security/security.xml
@@ -23,6 +23,14 @@
         <field name="name">Management Team</field>
         <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
     </record>
+    <record id="aicomsy_base.access_ncr_initiator" model="res.groups">
+        <field name="name">NCR Initiator</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
+    <record id="aicomsy_base.access_zonal_incharge" model="res.groups">
+        <field name="name">Zonal Incharge</field>
+        <field name="category_id" ref="aicomsy_base.aicomsy_category"/>
+    </record>
     <record id="aicomsy_base.access_administrator" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="aicomsy_base.aicomsy_category"/>

--- a/custom_addons/non_conformance_report/__manifest__.py
+++ b/custom_addons/non_conformance_report/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Non conformance Report',
-
+    'category': 'Aicomsy/Aicomsy',
     'depends': [
         'base', 'aicomsy_base', 'hr', 'account', 'mail'
     ],

--- a/custom_addons/non_conformance_report/__manifest__.py
+++ b/custom_addons/non_conformance_report/__manifest__.py
@@ -2,7 +2,7 @@
     'name': 'Non conformance Report',
 
     'depends': [
-        'base', 'aicomsy_base', 'hr', 'account',
+        'base', 'aicomsy_base', 'hr', 'account', 'mail'
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
@@ -13,14 +13,6 @@ class NCRDashboard(models.Model):
 
     @api.model
     def get_ncr_by_location(self, start_date, end_date, location,src, ncr):
-        start_date_object = None
-        end_date_object = None
-
-        if start_date is not None and start_date != '':
-            start_date_object = datetime.strptime(start_date, "%Y-%m-%d")
-
-        if end_date is not None and end_date != '':
-            end_date_object = datetime.strptime(end_date, "%Y-%m-%d")
 
         # Your initial query
         base_query = """ SELECT DATE(
@@ -28,7 +20,8 @@ class NCRDashboard(models.Model):
                                 TO_CHAR(ncr_open_date, 'MM') || '-01'
                             ) AS MOM,  loc.name, count(loc.name)
                         FROM x_ncr_report report
-                        LEFT JOIN x_location loc on loc.id = report. tag_no_location"""
+                        LEFT JOIN x_location loc on loc.id = report. tag_no_location
+                        LEFT JOIN x_ncr_nc as nc on nc.ncr_id = report.id"""
 
         # Construct the WHERE clause based on conditions
         conditions = []
@@ -41,9 +34,11 @@ class NCRDashboard(models.Model):
         elif end_date is not None and end_date != '':
             conditions.append(f"(ncr_open_date <= '{end_date}')")
 
+        if src is not None and src != 'null':
+            conditions.append(f"source_of_nc = '{src}'")
+
         if location is not None and location != 'null':
             conditions.append(f"tag_no_location = '{location}'")
-
 
         if ncr is not None and ncr != 'null':
             conditions.append(f"(report.create_uid = '{self.env.uid}' OR report.ncr_initiator_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}' "
@@ -63,20 +58,45 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_ncr_source_classification(self, start_date, end_date, location, ncr):
-        start_date_object = None
-        end_date_object = None
-
-        final_query = """SELECT  DATE(
+    def get_ncr_source_classification(self, start_date, end_date, location, src, ncr):
+        # Your initial query
+        base_query = """SELECT  DATE(
                                 TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
                                 TO_CHAR(ncr_open_date, 'MM') || '-01'
                             ) AS mom,                     
                 src.name as ncs_source, count(src.name) as count
                 FROM x_ncr_report as report  
                 LEFT JOIN x_ncr_nc as nc on nc.ncr_id = report.id
-                LEFT JOIN x_ncr_source  as src ON nc.source_of_nc = src.id  
-                GROUP BY mom,ncs_source"""
+                LEFT JOIN x_ncr_source  as src ON nc.source_of_nc = src.id"""
 
+        # Construct the WHERE clause based on conditions
+        conditions = []
+        if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
+            conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
+
+        elif start_date is not None and start_date != '':
+            conditions.append(f"(ncr_open_date >= '{start_date}'")
+
+        elif end_date is not None and end_date != '':
+            conditions.append(f"(ncr_open_date <= '{end_date}')")
+
+        if src is not None and src != 'null':
+            conditions.append(f"source_of_nc = '{src}'")
+
+        if location is not None and location != 'null':
+            conditions.append(f"tag_no_location = '{location}'")
+
+        if ncr is not None and ncr != 'null':
+            conditions.append(
+                f"(report.create_uid = '{self.env.uid}' OR report.ncr_initiator_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}' "
+                f" OR report.ncr_approver_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}')")
+
+        where_clause = " AND ".join(conditions)  # Final query with the dynamically constructed WHERE clause
+        if where_clause:
+            where_clause = f" WHERE {where_clause}"
+
+        final_query = f"{base_query} {where_clause} GROUP BY mom,ncs_source"
+        print("Final Query",final_query)
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()
 
@@ -87,19 +107,45 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_cost_of_rework(self, start_date, end_date, location, ncr):
-        start_date_object = None
-        end_date_object = None
-
-        final_query = """SELECT  DATE(
+    def get_cost_of_rework(self, start_date, end_date, location, src, ncr):
+        # Your initial query
+        base_query = """SELECT  DATE(
                             TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
                             TO_CHAR(ncr_open_date, 'MM') || '-01'
                         ) AS mom, ncr_type.name, sum(disposition_cost) as rework
                     FROM x_ncr_report AS  report
                     LEFT JOIN x_ncr_nc AS nc ON report.id = nc.ncr_id
                     LEFT JOIN x_ncr_type AS ncr_type ON report.ncr_type_id = ncr_type.id
-                    LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id
-                    GROUP BY mom, ncr_type_id, ncr_type.name"""
+                    LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id"""
+
+        # Construct the WHERE clause based on conditions
+        conditions = []
+        if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
+            conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
+
+        elif start_date is not None and start_date != '':
+            conditions.append(f"(ncr_open_date >= '{start_date}'")
+
+        elif end_date is not None and end_date != '':
+            conditions.append(f"(ncr_open_date <= '{end_date}')")
+
+        if src is not None and src != 'null':
+            conditions.append(f"source_of_nc = '{src}'")
+
+        if location is not None and location != 'null':
+            conditions.append(f"tag_no_location = '{location}'")
+
+        if ncr is not None and ncr != 'null':
+            conditions.append(
+                f"(report.create_uid = '{self.env.uid}' OR report.ncr_initiator_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}' "
+                f" OR report.ncr_approver_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}')")
+
+        where_clause = " AND ".join(conditions)  # Final query with the dynamically constructed WHERE clause
+        if where_clause:
+            where_clause = f" WHERE {where_clause}"
+
+        final_query = f"{base_query} {where_clause} GROUP BY mom, ncr_type_id, ncr_type.name"
+        print("Final Query", final_query)
 
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()
@@ -111,18 +157,42 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_customer_backcharges(self, start_date, end_date, location, ncr):
-        start_date_object = None
-        end_date_object = None
-
-        final_query = """SELECT  DATE(
+    def get_customer_backcharges(self, start_date, end_date, location, src, ncr):
+        # Your initial query
+        base_query = """SELECT  DATE(
                                 TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
                                 TO_CHAR(ncr_open_date, 'MM') || '-01'
                             ) AS mom, project_number, sum(estimated_backcharge_price) as backcharges
                             FROM x_ncr_report AS  report
                             LEFT JOIN x_ncr_nc AS nc ON report.id = nc.ncr_id
-                            LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id
-                            GROUP BY mom, project_number"""
+                            LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id"""
+
+        # Construct the WHERE clause based on conditions
+        conditions = []
+        if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
+            conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
+
+        elif start_date is not None and start_date != '':
+            conditions.append(f"(ncr_open_date >= '{start_date}'")
+
+        elif end_date is not None and end_date != '':
+            conditions.append(f"(ncr_open_date <= '{end_date}')")
+
+        if src is not None and src != 'null':
+            conditions.append(f"source_of_nc = '{src}'")
+
+        if location is not None and location != 'null':
+            conditions.append(f"tag_no_location = '{location}'")
+
+        if ncr is not None and ncr != 'null':
+            conditions.append(
+                f"(report.create_uid = '{self.env.uid}' OR report.ncr_initiator_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}' "
+                f" OR report.ncr_approver_id = '{self.env['hr.employee'].search([('user_id', '=', self.env.uid)]).id}')")
+
+        where_clause = " AND ".join(conditions)  # Final query with the dynamically constructed WHERE clause
+        if where_clause:
+            where_clause = f" WHERE {where_clause}"
+        final_query = f"{base_query} {where_clause} GROUP BY mom, project_number"
 
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()

--- a/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
@@ -96,7 +96,6 @@ class NCRDashboard(models.Model):
             where_clause = f" WHERE {where_clause}"
 
         final_query = f"{base_query} {where_clause} GROUP BY mom,ncs_source"
-        print("Final Query",final_query)
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()
 
@@ -145,7 +144,6 @@ class NCRDashboard(models.Model):
             where_clause = f" WHERE {where_clause}"
 
         final_query = f"{base_query} {where_clause} GROUP BY mom, ncr_type_id, ncr_type.name"
-        print("Final Query", final_query)
 
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -3,6 +3,7 @@ from odoo import models, fields, api
 # Define the NcrReport class
 class NcrReport(models.Model):
     _name = 'x.ncr.report'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = 'NCR Report'
 
     # Override the create method to set default values and generate a unique name
@@ -15,7 +16,7 @@ class NcrReport(models.Model):
 
     # Fields for NcrReport
     name = fields.Char(string="NCR Reference", default='New', readonly=True, required=True)
-    ncr_type_id = fields.Many2one('x.ncr.type', string='NCR Type', required=True)
+    ncr_type_id = fields.Many2one('x.ncr.type', string='NCR Type', required=True, tracking=True)
     discipline_id = fields.Many2one('x.ncr.discipline', string='Discipline')
     supplier_name_id = fields.Many2one('res.partner', domain=[('supplier_rank', '>', 0)], string='Supplier Name')
     purchase_order_no = fields.Char(string='Purchase Order No.')
@@ -26,10 +27,10 @@ class NcrReport(models.Model):
     received_date = fields.Date(string='Received Date')
     inspection_stage = fields.Char(string='Inspection Stage')
     rfi_number = fields.Char(string='RFI Number')
-    ncr_initiator_id = fields.Many2one('hr.employee', string='NCR Initiator Name', required=True)
+    ncr_initiator_id = fields.Many2one('hr.employee', string='NCR Initiator Name', required=True, tracking=True)
     initiator_job_title = fields.Char(related='ncr_initiator_id.job_id.name', string="Job Title")
-    ncr_open_date = fields.Date(string='NCR Open Date', required=True)
-    ncr_approver_id = fields.Many2one('hr.employee', string='NCR Approver Name', related='ncr_initiator_id.parent_id', store=True)
+    ncr_open_date = fields.Date(string='NCR Open Date', required=True, tracking=True)
+    ncr_approver_id = fields.Many2one('hr.employee', string='NCR Approver Name', related='ncr_initiator_id.parent_id', store=True, tracking=True)
     approver_job_title = fields.Char(related='ncr_approver_id.parent_id.job_id.name', string="Job Title", store=True)
     rca_response_due_date = fields.Date(string='RCA Response Due Date')
     ncr_category_id = fields.Many2one(comodel_name='x.ncr.category', string='NCR Category')
@@ -46,7 +47,7 @@ class NcrReport(models.Model):
             ('approved', 'Approved'),
             ('rejected', 'Rejected'),
             ('return_for_further_actions', 'Return for Further Actions'),
-        ]
+        ], tracking=True
         # Set a default value for the state field
     )
 

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -27,10 +27,11 @@ class NcrReport(models.Model):
     received_date = fields.Date(string='Received Date')
     inspection_stage = fields.Char(string='Inspection Stage')
     rfi_number = fields.Char(string='RFI Number')
-    ncr_initiator_id = fields.Many2one('hr.employee', string='NCR Initiator Name', required=True, tracking=True)
+    ncr_initiator_id = fields.Many2one('hr.employee', string='NCR Initiator Name', required=True, default=lambda
+        self: self.env.user.employee_id.id if self.env.user.employee_id else False, tracking=True)
     initiator_job_title = fields.Char(related='ncr_initiator_id.job_id.name', string="Job Title")
-    ncr_open_date = fields.Date(string='NCR Open Date', required=True, tracking=True)
-    ncr_approver_id = fields.Many2one('hr.employee', string='NCR Approver Name', related='ncr_initiator_id.parent_id', store=True, tracking=True)
+    ncr_open_date = fields.Date(string='NCR Open Date', required=True, default=fields.Date.context_today, tracking=True)
+    ncr_approver_id = fields.Many2one('hr.employee', string='NCR Approver Name', related='ncr_approver_id.parent_id', store=True, tracking=True)
     approver_job_title = fields.Char(related='ncr_approver_id.parent_id.job_id.name', string="Job Title", store=True)
     rca_response_due_date = fields.Date(string='RCA Response Due Date')
     ncr_category_id = fields.Many2one(comodel_name='x.ncr.category', string='NCR Category')
@@ -116,6 +117,7 @@ class NcrReport(models.Model):
             'model_description': self.with_context().name,
         }
         return {
+            'name': 'Email',
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'mail.compose.message',

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -67,6 +67,7 @@ class NcrResponse(models.Model):
             'model_description': self.with_context().name,
         }
         return {
+            'name': 'Email',
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'mail.compose.message',

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -4,6 +4,7 @@ from odoo.exceptions import ValidationError
 
 class NcrResponse(models.Model):
     _name = 'x.ncr.response'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = 'NCR Response'
 
     @api.model
@@ -23,26 +24,26 @@ class NcrResponse(models.Model):
     ncr_id = fields.Many2one("x.ncr.report", string='NCR No.')
     project_number = fields.Char(related="ncr_id.project_number", string='Project Number')
     project_name_title = fields.Char(related="ncr_id.project_name_title", string='Project Name / Title')
-    supplier_response = fields.Text(string='Supplier Response')
-    prepared_by_id = fields.Many2one('hr.employee', string='Prepared by', required=True)
-    reviewed_and_approved_by_id = fields.Many2one('hr.employee', string='Reviewed & Approved by', required=True)
-    prepared_by_signature_date = fields.Char(string='Signature With Date', help='Maximum 30 character only')
-    reviewed_by_signature_date = fields.Char(string='Signature With Date', help='Maximum 30 character only')
+    supplier_response = fields.Text(string='Supplier Response', tracking=True)
+    prepared_by_id = fields.Many2one('hr.employee', string='Prepared by', required=True, tracking=True)
+    reviewed_and_approved_by_id = fields.Many2one('hr.employee', string='Reviewed & Approved by', required=True, tracking=True)
+    prepared_by_signature_date = fields.Char(string='Signature With Date', help='Maximum 30 character only', tracking=True)
+    reviewed_by_signature_date = fields.Char(string='Signature With Date', help='Maximum 30 character only', tracking=True)
     prepared_by_title = fields.Char(related='prepared_by_id.job_id.name', string='Title')
     reviewed_by_title = fields.Char(related='reviewed_and_approved_by_id.job_id.name', string='Title')
     total_cost_for_rework = fields.Float(string='Total Cost for Rework')
-    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name')
+    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name', tracking=True)
     ncr_completion_status = fields.Char(string='NCR Completion Status')
     total_backcharge_amount = fields.Float(string='Total Backcharge Amount')
     title = fields.Char(related='rca_approver_id.job_id.name', string='Title')
-    ncr_closed_date = fields.Date(string='NCR Closed Date')
+    ncr_closed_date = fields.Date(string='NCR Closed Date', tracking=True)
     ncr_nc_ids = fields.One2many('x.ncr.nc', 'ncr_response_id', string='NCR NC')
     state = fields.Selection(
         selection=[("new", "New"),
                    ("review_in_progress", "Review in Progress"),
                    ("closed", "Closed")
                    ],
-        default="new",  # Set a default value for the state field
+        default="new", tracking=True  # Set a default value for the state field
     )
 
     def save_and_submit(self):

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -37,7 +37,6 @@ class NcrResponse(models.Model):
     title = fields.Char(related='rca_approver_id.job_id.name', string='Title')
     ncr_closed_date = fields.Date(string='NCR Closed Date')
     ncr_nc_ids = fields.One2many('x.ncr.nc', 'ncr_response_id', string='NCR NC')
-
     state = fields.Selection(
         selection=[("new", "New"),
                    ("review_in_progress", "Review in Progress"),
@@ -85,7 +84,7 @@ class NcrResponse(models.Model):
         # Additional logic can be added here if needed
         return True
 
-    @api.constrains('signature_with_date_1', 'signature_with_date_2', 'title_1', 'title_2')
+    @api.constrains('prepared_by_signature_date', 'reviewed_by_signature_date')
     def _check_fields_size(self):
         for record in self:
             if record.prepared_by_signature_date and len(record.prepared_by_signature_date) > 30:

--- a/custom_addons/non_conformance_report/static/src/js/dashboard.js
+++ b/custom_addons/non_conformance_report/static/src/js/dashboard.js
@@ -8,15 +8,12 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
     var session = require('web.session');
     var _t = core._t;
     var web_client = require('web.web_client');
+    // Declare an array to store chart instances
+    var chartInstances = [];
     var NCRDashboard = AbstractAction.extend({
         template: 'NCRDashboard',
         events: {
-
-            'change #start_date': '_onchangeFilter',
-            'change #end_date': '_onchangeFilter',
-            'change #locations_selection': '_onchangeFilter',
-            'change #src_selection': '_onchangeFilter',
-            'change #ncr_selection': '_onchangeFilter',
+            'click #apply_btn': '_onchangeFilter',
         },
         init: function(parent, context) {
             this._super(parent, context);
@@ -104,11 +101,23 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
                     var color = '#1183DC';
                     return color;
                 },
-         /**
+
+        // Function to destroy existing charts
+         destroyCharts: function() {
+            if (chartInstances.length > 0) {
+                chartInstances.forEach(function (chart) {
+                    chart.destroy();
+                });
+                chartInstances = [];
+            }
+        },
+
+        /**
         rendering the graph
         */
         render_graphs: function() {
             var self = this;
+            self.destroyCharts()
             self.render_ncr_by_location();
             self.render_ncr_source_classification_graph();
             self.render_ncr_cost_of_rework_graph();
@@ -224,6 +233,8 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
                 data: chartData,
                 options: options
             });
+            // Save the chart instance for later use
+            chartInstances.push(chart);
 
             // Function to generate random color
             function getRandomColor() {
@@ -269,11 +280,12 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
             var start_date = $('#start_date').val();
             var end_date = $('#end_date').val();
             var location = $('#locations_selection').val();
+            var src_selection = $('#src_selection').val();
             var ncr_selection = $('#ncr_selection').val();
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_ncr_source_classification',
-                        args: [start_date, end_date, location, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',
@@ -293,11 +305,12 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
             var start_date = $('#start_date').val();
             var end_date = $('#end_date').val();
             var location = $('#locations_selection').val();
+            var src_selection = $('#src_selection').val();
             var ncr_selection = $('#ncr_selection').val();
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_cost_of_rework',
-                        args: [start_date, end_date, location, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',
@@ -317,11 +330,12 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
             var start_date = $('#start_date').val();
             var end_date = $('#end_date').val();
             var location = $('#locations_selection').val();
+            var src_selection = $('#src_selection').val();
             var ncr_selection = $('#ncr_selection').val();
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_customer_backcharges',
-                        args: [start_date, end_date, location, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',

--- a/custom_addons/non_conformance_report/static/src/xml/dashboard.xml
+++ b/custom_addons/non_conformance_report/static/src/xml/dashboard.xml
@@ -38,6 +38,9 @@
                         <option value="my">My NCRs</option>
                     </select>
                 </p>
+                <p>
+                    <button type="button" id="apply_btn" class="inner_select btn-primary">Apply</button>
+                </p>
 
             </div>
 

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -33,7 +33,7 @@
                     <h>
                         <field name="name"/>
                     </h>
-                    <group col="3">
+                    <group col="2">
                         <group>
                             <field name="ncr_type_check" invisible="1"/>
                             <field name="ncr_type_id"/>

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -88,6 +88,11 @@
                             class="btn-primary col-5" states="approval_pending"/>
 
                 </sheet>
+                <div class="oe_chatter">
+                     <field name="message_follower_ids"/>
+                     <field name="activity_ids"/>
+                     <field name="message_ids"/>
+                </div>
             </form>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -99,6 +99,11 @@
                         </group>
                     </group>
                 </sheet>
+                 <div class="oe_chatter">
+                     <field name="message_follower_ids"/>
+                     <field name="activity_ids"/>
+                     <field name="message_ids"/>
+                </div>
             </form>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -2,6 +2,7 @@
     <record id="x_ncr_response_action" model="ir.actions.act_window">
         <field name="name">NCR Responses</field>
         <field name="res_model">x.ncr.response</field>
+        <field name="context">{'create': False}</field>
         <field name="view_mode">tree,form</field>
     </record>
     <record id="x_ncr_response_view_tree" model="ir.ui.view">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: On hover over charts, old charts was getting displayed. Added filter apply button instead of refreshing charts for every filter selection

Current behavior before PR: For every filter selection, charts will be re-rendered.  On mouse hover , old charts were getting dispayed

Desired behavior after PR is merged: Only on click of apply button, the charts should be re-rendered. On mouse hover over the charts, it should not display old charts




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
