### PR TITLE
[FIX] Fixed charts and included apply button for filters in Incident Management

### DIFF
--- a/custom_addons/incident_management/static/src/js/incident_dashboard.js
+++ b/custom_addons/incident_management/static/src/js/incident_dashboard.js
@@ -8,14 +8,12 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
     var session = require('web.session');
     var _t = core._t;
     var web_client = require('web.web_client');
+    var chartInstances = [];
     var IncidentDashboard = AbstractAction.extend({
         template: 'IncidentDashboard',
         events: {
             'click .tot_incidents': 'tot_incidents',
-            'change #start_date': '_onchangeFilter',
-            'change #end_date': '_onchangeFilter',
-            'change #locations_selection': '_onchangeFilter',
-            'change #incidents_selection': '_onchangeFilter',
+            'click #apply_btn': '_onchangeFilter',
         },
         init: function(parent, context) {
             this._super(parent, context);
@@ -59,6 +57,16 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                 });
             })
         },
+        // Function to destroy existing charts
+         destroyCharts: function() {
+            if (chartInstances.length > 0) {
+                chartInstances.forEach(function (chart) {
+                    chart.destroy();
+                });
+                chartInstances = [];
+            }
+        },
+
         /**
         function for getting values to the filters
         */
@@ -101,6 +109,7 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
         */
         render_graphs: function() {
             var self = this;
+            self.destroyCharts()
             self.render_inc_severity_graph();
             self.render_inc_cost_impact_graph();
             self.render_normal_days_mom_graph();
@@ -164,7 +173,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                     data: data,
                     options: options
                 });
-
+                // Save the chart instance for later use
+                chartInstances.push(chart);
 
             });
 
@@ -250,6 +260,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                     data: data,
                     options: options
                 });
+                // Save the chart instance for later use
+                chartInstances.push(chart);
 
             });
 
@@ -311,6 +323,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                     data: data,
                     options: options
                 });
+                // Save the chart instance for later use
+                chartInstances.push(chart);
 
             });
 
@@ -462,6 +476,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                             data: chartData,
                             options: options
                         });
+                        // Save the chart instance for later use
+                        chartInstances.push(chart);
 
                         // Function to generate random color
                         function getRandomColor() {
@@ -530,6 +546,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                     data: data,
                     options: options
                 });
+                // Save the chart instance for later use
+                chartInstances.push(chart);
 
             });
 
@@ -593,6 +611,8 @@ odoo.define('incident_dashboard.Dashboard', function(require) {
                     data: data,
                     options: options
                 });
+                // Save the chart instance for later use
+                chartInstances.push(chart);
 
             });
         },

--- a/custom_addons/incident_management/static/src/xml/incident_dashboard.xml
+++ b/custom_addons/incident_management/static/src/xml/incident_dashboard.xml
@@ -32,6 +32,9 @@
                         <option value="my">My Incidents</option>
                     </select>
                 </p>
+                 <p>
+                    <button type="button" id="apply_btn" class="inner_select btn-primary">Apply</button>
+                </p>
             </div>
 
             <div class="col-md-4 col-sm-6 oh-payslip">

--- a/custom_addons/non_conformance_report/__manifest__.py
+++ b/custom_addons/non_conformance_report/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    'name': 'Non conformance Report',
+    'name': 'Non conformance Management',
     'category': 'Aicomsy/Aicomsy',
     'depends': [
         'base', 'aicomsy_base', 'hr', 'account', 'mail'

--- a/custom_addons/non_conformance_report/views/x_ncr_menu.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_menu.xml
@@ -1,5 +1,5 @@
 <odoo>
-    <menuitem id="non_conformance_report" name="Non Conformance Report" sequence="1">
+    <menuitem id="non_conformance_report" name="Non Conformance Management" sequence="1">
         <menuitem id="non_conformance" name="Report" sequence="2">
             <menuitem id="x_ncr_report_menu_action" action="x_ncr_report_action"/>
         </menuitem>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: On Mouse moveover  the previous chart are getting displayed and added apply button for filters instead of individual filter onchange

Current behavior before PR: When each filter is changes the charts are re-rendered. When mouse moveover is done on the charts, previous charts are getting displayed

Desired behavior after PR is merged: Now the previous charts are destroyed so on mouse moveover issue should not happen. Apply button is added to render charts based on filter changes




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
