### PR TITLE
[FIX] Added Mandatory fields and options

### DIFF
--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -45,11 +45,11 @@
                             <field name="uom"
                                    attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}" options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
                                    attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="source_of_nc"

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -38,10 +38,9 @@
                     <group col="2">
                         <group>
                             <field name="ncr_type_check" invisible="1"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
-                            <field name="ncr_type_id"
                                    attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                            <field name="ncr_type_id"
+                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="discipline_id"
                                    attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
@@ -55,7 +54,7 @@
                             <field name="project_name_title"
                                    attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
                             <field name="tag_no_location"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="shipment_reference"
@@ -71,10 +70,10 @@
                     <field name="ncr_nc_ids">
                         <tree editable="bottom">
                             <field name="nc_s"/>
-                            <field name="source_of_nc"/>
-                            <field name="nc_description"/>
-                            <field name="uom"/>
-                            <field name="quantity"/>
+                            <field name="source_of_nc" options="{'no_create': True, 'no_create_edit': True, 'required': True}" />
+                           <field name="nc_description" required="True" />
+                            <field name="uom" required="True"/>
+                            <field name="quantity" required="True"/>
                             <button string="Add Details" type="object" class="oe_highlight" icon="fa-plus"
                                     name="nc_part_details_popup"/>
                             <field name="attachment_ids" string="Attachments" widget="many2many_binary"

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -42,8 +42,7 @@
                     <field name="ncr_nc_ids" attrs="{'invisible': [('state', 'not in', ['new'])]}">
                         <tree>
                             <field name="nc_s"/>
-                            <field name="cause_of_nc_id" attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="cause_of_nc_id" attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
                             <field name="disposition_type_id"/>
                             <field name="immediate_action"
                                    attrs="{'column_invisible': [('parent.state', 'not in', ['new'])]}"/>
@@ -54,8 +53,7 @@
                             <field name="disposition_action"
                                    attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                             <field name="review_comments" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                            <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                         </tree>
                     </field>
                     <group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In x_ncr_nc views cause_of_nc_id,ca_response_id for these fields options had been added. x_ncr_report view source_of_nc,nc_description,uom, quantity mandatory had been added
x_ncr_response view cause_of_nc_id,ca_response_id option had been removed

Current behavior before PR: Not added mandatory fields and options

Desired behavior after PR is merged: Had been added mandatory fields and options




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
