### PR TITLE
[FIX] Added Mandatory fields,comments and compute field

### DIFF
--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -2,6 +2,7 @@ from odoo import models, fields, api
 from odoo.exceptions import ValidationError
 
 
+# Define NonConformanceModel class
 class NonConformanceModel(models.Model):
     _name = 'x.ncr.nc'
     _description = 'Non-Conformance Model'
@@ -94,7 +95,7 @@ class NonConformanceModel(models.Model):
         }
 
 
-# Define YourModelName class
+# Define NCRSource class
 class NCRSource(models.Model):
     _name = 'x.ncr.source'
     _description = 'x NCR Source'

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -108,13 +108,16 @@ class NcrReport(models.Model):
 
     # Your logic for Approve and Submit
     def approve_and_submit(self):
+        # Get the email template for NCR approval
         mail_template = self.env.ref('non_conformance_report.email_template_ncr')
+        # Send approval email and force_send=True ensures the email is sent immediately
         mail_template.send_mail(self.id, force_send=True)
         self.mark_activity_as_done("Approval Pending")
         if self.tag_no_location.location_incharge.user_id.id != False:
             self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id, self.due_date)
         self.write({'state': 'approved'})
 
+        # Update the state of associated Non-Conformance Records to 'ncr_submitted'
         nc_records = self.mapped('ncr_nc_ids')
 
         for nc in nc_records:
@@ -123,6 +126,7 @@ class NcrReport(models.Model):
 
 
     def add_supplier(self):
+        # Open a form to add a new supplier
         return {
             'name': 'Add Supplier',
             'type': 'ir.actions.act_window',
@@ -142,6 +146,7 @@ class NcrReport(models.Model):
         }
 
     def assign_incharge(self):
+        # Open a form to assign an in-charge for NCR response
         self.mark_activity_as_done("Assign Response Handler")
         self.write({'state': 'awaiting_vendor_response'})
         return {

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -45,22 +45,24 @@
                             <field name="uom"
                                    attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="source_of_nc"
                                    attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="immediate_action"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
                                    attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
                             <field name="disposition_type_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': True}"
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="disposition_action"
                                    attrs="{'readonly': [('state', '=', 'received_vendor_response')]}"/>
@@ -110,7 +112,6 @@
                         <field name="completion_percentage"/>
                         <field name="production_date"/>
                         <field name="quantity"/>
-                        <field name="quarantine" widget="radio" options="{'horizontal': true}" style="display: inline"/>
                     </group>
                     <group>
                         <field name="operator_employee_id"/>
@@ -118,8 +119,7 @@
                         <field name="disposition_priority"/>
                         <field name="disposition_cost"/>
                         <field name="estimated_backcharge_price"/>
-                        <field name="nc_details_id" options="{'no_create': True, 'no_create_edit':True}"/>
-                        <field name="ncr_id"/>
+                        <field name="quarantine" widget="radio" options="{'horizontal': true}" style="display: inline"/>
                     </group>
                 </group>
             </form>

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -39,33 +39,33 @@
                     <group col="2">
                         <group>
                             <field name="nc_s"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
                             <field name="nc_description" default_focus="1"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
                             <field name="uom"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response', ('state', '=', 'approved'))], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="source_of_nc"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"
+                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="immediate_action"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
                             <field name="disposition_type_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="disposition_action"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')]}"/>
                             <field name="review_comments"/>
                         </group>
                     </group>

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -39,33 +39,33 @@
                     <group col="2">
                         <group>
                             <field name="nc_s"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
+                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
                             <field name="nc_description" default_focus="1"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
+                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
                             <field name="uom"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
+                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response', ('state', '=', 'approved'))], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="source_of_nc"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"
+                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="immediate_action"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
-                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response')]}"/>
+                                   attrs="{'readonly': ['|', ('state', '=', 'ncr_submitted'), ('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
                             <field name="disposition_type_id"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="disposition_action"
-                                   attrs="{'readonly': [('state', '=', 'received_vendor_response')]}"/>
+                                   attrs="{'readonly': [('state', '=', 'received_vendor_response'), ('state', '=', 'approved')]}"/>
                             <field name="review_comments"/>
                         </group>
                     </group>

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -39,33 +39,33 @@
                     <group col="2">
                         <group>
                             <field name="nc_s"
-                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="nc_description" default_focus="1"
-                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="uom"
-                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="source_of_nc"
-                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"
+                                   attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="immediate_action"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
-                                   attrs="{'readonly': [ ('state', 'in', 'ncr_submitted', 'received_vendor_response', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="disposition_type_id"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="disposition_action"
-                                   attrs="{'readonly': [ ('state', 'in', 'received_vendor_response', 'approved')]}"/>
+                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])]}"/>
                             <field name="review_comments"/>
                         </group>
                     </group>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -15,6 +15,7 @@
                 <field name="project_name_title"/>
                 <field name="project_number"/>
                 <field name="state"/>
+                <field name="assigned_to_id"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In x_ncr_nc model had been added two comments
x_ncr_nc views had been added required attrs.
x_ncr_report model comments had been added
x_ncr_response model comments,assigned_to_id field, states and commpute had been added 
x_ncr_response view had been added assigned_to_id field

Current behavior before PR: Assigned_to_id field not added

Desired behavior after PR is merged: Assigned_to_id field had been added




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
