### PR TITLE
[FIX] Added Related in rca.response.type

### DIFF
--- a/custom_addons/non_conformance_report/data/x_ncr_ca_response_data.xml
+++ b/custom_addons/non_conformance_report/data/x_ncr_ca_response_data.xml
@@ -2,15 +2,19 @@
     <data noupdate="1">
         <record id="rca1" model="x.ncr.ca.response">
             <field name="name">CODE-1</field>
+            <field name="nam">Accepted, No Follow-Up Required</field>
         </record>
         <record id="rca2" model="x.ncr.ca.response">
             <field name="name">CODE-2</field>
+            <field name="nam">Accepted, Follow-Up Required</field>
         </record>
         <record id="rca3" model="x.ncr.ca.response">
             <field name="name">CODE-3</field>
+            <field name="nam">Revise &amp; Resubmit</field>
         </record>
         <record id="rca4" model="x.ncr.ca.response">
             <field name="name">CODE-4</field>
+            <field name="nam">Rejected</field>
         </record>
     </data>
 </odoo>

--- a/custom_addons/non_conformance_report/data/x_ncr_ca_response_data.xml
+++ b/custom_addons/non_conformance_report/data/x_ncr_ca_response_data.xml
@@ -2,19 +2,19 @@
     <data noupdate="1">
         <record id="rca1" model="x.ncr.ca.response">
             <field name="name">CODE-1</field>
-            <field name="nam">Accepted, No Follow-Up Required</field>
+            <field name="rca_response">Accepted, No Follow-Up Required</field>
         </record>
         <record id="rca2" model="x.ncr.ca.response">
             <field name="name">CODE-2</field>
-            <field name="nam">Accepted, Follow-Up Required</field>
+            <field name="rca_response">Accepted, Follow-Up Required</field>
         </record>
         <record id="rca3" model="x.ncr.ca.response">
             <field name="name">CODE-3</field>
-            <field name="nam">Revise &amp; Resubmit</field>
+            <field name="rca_response">Revise &amp; Resubmit</field>
         </record>
         <record id="rca4" model="x.ncr.ca.response">
             <field name="name">CODE-4</field>
-            <field name="nam">Rejected</field>
+            <field name="rca_response">Rejected</field>
         </record>
     </data>
 </odoo>

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -65,6 +65,7 @@ class NonConformanceModel(models.Model):
     response_attachment_ids = fields.One2many('ir.attachment', 'res_id', string="RCA / CA Response")
     review_comments = fields.Text(string='Review Comments (If Any)', help='Max 400 Characters')
     ca_response_id = fields.Many2one('x.ncr.ca.response', string='RCA Response')
+    rca_response_type1 = fields.Char(related='ca_response_id.nam', string="RCA Response Type", store=True)
     disposition_action = fields.Selection(
         [('accept', 'Accept'), ('reject', 'Reject')],
         string='Disposition Action',
@@ -146,3 +147,4 @@ class NcrCaResponse(models.Model):
     _description = 'NCR RCA Response'
 
     name = fields.Char(string='Name', required=True)
+    nam = fields.Char(string='Response Type')

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -65,7 +65,7 @@ class NonConformanceModel(models.Model):
     response_attachment_ids = fields.One2many('ir.attachment', 'res_id', string="RCA / CA Response")
     review_comments = fields.Text(string='Review Comments (If Any)', help='Max 400 Characters')
     ca_response_id = fields.Many2one('x.ncr.ca.response', string='RCA Response')
-    rca_response_type1 = fields.Char(related='ca_response_id.nam', string="RCA Response Type", store=True)
+    rca_response = fields.Char(related='ca_response_id.rca_response', string="RCA Response", store=True)
     disposition_action = fields.Selection(
         [('accept', 'Accept'), ('reject', 'Reject')],
         string='Disposition Action',
@@ -147,4 +147,4 @@ class NcrCaResponse(models.Model):
     _description = 'NCR RCA Response'
 
     name = fields.Char(string='Name', required=True)
-    nam = fields.Char(string='Response Type')
+    rca_response = fields.Char(string='Response Type')

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -52,6 +52,7 @@
                             <field name="ca_response_id"
                                    attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="rca_response_type1"/>
                         </group>
                         <group>
                             <field name="source_of_nc"

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -52,7 +52,7 @@
                             <field name="ca_response_id"
                                    attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
-                            <field name="rca_response_type1"/>
+                            <field name="rca_response"/>
                         </group>
                         <group>
                             <field name="source_of_nc"

--- a/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
@@ -81,6 +81,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="name"/>
+                <field name="nam"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
@@ -81,7 +81,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="name"/>
-                <field name="nam"/>
+                <field name="rca_response"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -55,6 +55,7 @@
                                    attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                             <field name="review_comments" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                             <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
+                            <field name="rca_response_type1"/>
                         </tree>
                     </field>
                     <group>
@@ -99,6 +100,7 @@
                                        attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                                 <field name="ca_response_id"
                                        attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
+                                <field name="rca_response_type1"/>
                             </tree>
                         </field>
                         <group col="2" attrs="{'invisible': [('state', '=', 'new')]}">

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -55,7 +55,7 @@
                                    attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                             <field name="review_comments" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                             <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                            <field name="rca_response_type1"/>
+                            <field name="rca_response"/>
                         </tree>
                     </field>
                     <group>
@@ -100,7 +100,7 @@
                                        attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
                                 <field name="ca_response_id"
                                        attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                                <field name="rca_response_type1"/>
+                                <field name="rca_response"/>
                             </tree>
                         </field>
                         <group col="2" attrs="{'invisible': [('state', '=', 'new')]}">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: In x_ncr_nc.py model had been added related field
In view had been added field rca_response_type1

Current behavior before PR: rca_response_type1 not added
 

Desired behavior after PR is merged: rca_response_type1 field had been added




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
