### PR TITLE
[FIX] Workflow and Dashboard for NCR

### DIFF
--- a/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
@@ -95,7 +95,7 @@ class NCRDashboard(models.Model):
         if where_clause:
             where_clause = f" WHERE {where_clause}"
 
-        final_query = f"{base_query} {where_clause} GROUP BY mom,ncs_source"
+        final_query = f"{base_query} {where_clause} GROUP BY mom,ncs_source ORDER BY mom"
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()
 
@@ -143,7 +143,7 @@ class NCRDashboard(models.Model):
         if where_clause:
             where_clause = f" WHERE {where_clause}"
 
-        final_query = f"{base_query} {where_clause} GROUP BY mom, ncr_type_id, ncr_type.name"
+        final_query = f"{base_query} {where_clause} GROUP BY mom, ncr_type_id, ncr_type.name ORDER BY mom"
 
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()
@@ -190,7 +190,7 @@ class NCRDashboard(models.Model):
         where_clause = " AND ".join(conditions)  # Final query with the dynamically constructed WHERE clause
         if where_clause:
             where_clause = f" WHERE {where_clause}"
-        final_query = f"{base_query} {where_clause} GROUP BY mom, project_number"
+        final_query = f"{base_query} {where_clause} GROUP BY mom, project_number ORDER BY mom"
 
         self.env.cr.execute(final_query)
         result = self.env.cr.fetchall()

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -41,6 +41,16 @@ class NonConformanceModel(models.Model):
             ncr_nc_records.write({'ncr_response_id': ncr_resp_id})
         return nc
 
+    def write(self, values):
+        # Add your custom validation logic here before updating the record
+        for records in self:
+            if records.state == 'received_vendor_response':
+                if ((not 'disposition_action' in values or not 'ca_response_id' in values)
+                        and (records.disposition_action == None or records.ca_response_id == None)):
+                    raise ValidationError("Enter the required parameters: Disposition Type, Disposition Action and RCA Response")
+
+        return super().write(values)
+
     @api.constrains('nc_description', 'uom')
     def _check_fields_size(self):
         for record in self:
@@ -66,7 +76,7 @@ class NonConformanceModel(models.Model):
     review_comments = fields.Text(string='Review Comments (If Any)', help='Max 400 Characters')
     ca_response_id = fields.Many2one('x.ncr.ca.response', string='RCA Response')
     disposition_action = fields.Selection(
-        [('accept', 'Accept'), ('reject', 'Reject')],
+        [('accept', 'Accept'), ('reject', 'Reject'), ('reinspect', 'Reinspect')],
         string='Disposition Action',
     )
     state = fields.Selection(

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -41,7 +41,7 @@ class NcrResponse(models.Model):
     reviewed_by_title = fields.Char(related='reviewed_and_approved_by_id.job_id.name', string='Title')
     manual_total_cost_rework = fields.Float(string='Total Cost for Rework')
     total_cost_for_rework = fields.Float(string='Total Cost for Rework', compute='_compute_total_cost_for_rework', inverse="_inverse_total_cost_rework_editable")
-    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name', compute="_compute_rca_approver", tracking=True)
+    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name', related="ncr_id.ncr_approver_id", tracking=True)
     ncr_completion_status = fields.Char(string='NCR Completion Status', compute='_compute_ncr_completion_status')
     manual_total_backcharge = fields.Float(string='Total Backcharge Amount')
     total_backcharge_amount = fields.Float(string='Total Backcharge Amount', compute='_compute_total_backcharge', inverse="_inverse_total_backcharge" )

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
+from datetime import datetime, timedelta
 
 
 class NcrResponse(models.Model):
@@ -13,9 +14,13 @@ class NcrResponse(models.Model):
         vals_list['name'] = self.env['ir.sequence'].next_by_code("x.ncr.response")
         # Set default state to 'assigned'
         vals_list['state'] = 'new'
-
+        ncr_id = self.env.context.get('default_ncr_id')
         # Create the NCR response
         response = super().create(vals_list)
+        # Change the state of the related incident
+        if ncr_id:
+            ncr = self.env['x.ncr.report'].browse(ncr_id)
+            ncr.write({'state': 'awaiting_vendor_response'})
 
         return response
 
@@ -34,33 +39,55 @@ class NcrResponse(models.Model):
                                              tracking=True)
     prepared_by_title = fields.Char(related='prepared_by_id.job_id.name', string='Title')
     reviewed_by_title = fields.Char(related='reviewed_and_approved_by_id.job_id.name', string='Title')
-    total_cost_for_rework = fields.Float(string='Total Cost for Rework', compute='_compute_total_cost_for_rework')
-    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name', tracking=True)
+    manual_total_cost_rework = fields.Float(string='Total Cost for Rework')
+    total_cost_for_rework = fields.Float(string='Total Cost for Rework', compute='_compute_total_cost_for_rework', inverse="_inverse_total_cost_rework_editable")
+    rca_approver_id = fields.Many2one('hr.employee', string='RCA Approver Name', compute="_compute_rca_approver", tracking=True)
     ncr_completion_status = fields.Char(string='NCR Completion Status', compute='_compute_ncr_completion_status')
-    total_backcharge_amount = fields.Float(string='Total Backcharge Amount', compute='_compute_total_backcharge',)
+    manual_total_backcharge = fields.Float(string='Total Backcharge Amount')
+    total_backcharge_amount = fields.Float(string='Total Backcharge Amount', compute='_compute_total_backcharge', inverse="_inverse_total_backcharge" )
     title = fields.Char(related='rca_approver_id.job_id.name', string='Title')
     ncr_closed_date = fields.Date(string='NCR Closed Date', tracking=True)
     ncr_nc_ids = fields.One2many('x.ncr.nc', 'ncr_response_id', string='NCR NC')
     show_approve_button = fields.Boolean("Show Approve Button", default=False, store=False)
+    to_reinspect = fields.Boolean(" Items in Reinspect", default=False, store=False, compute='_compute_to_reinspect')
+    to_reject = fields.Boolean(" Items in Reject", default=False, store=False, compute='_compute_to_reject')
     assigned_to_id = fields.Many2one('hr.employee', string='Assigned to', compute='_compute_assignee')
     state = fields.Selection(
-        selection=[("new", "New"),
+        selection=[("draft", "Draft"),
+                   ("new", "New"),
                    ("review_in_progress", "Review in Progress"),
-                   ('approval_pending', 'Approval Pending'),
+                   ("approval_pending", "Approval Pending"),
+                   ("review_rejection", "Review Rejection"),
                    ("closed", "Closed")
                    ],
-        default="new", tracking=True  # Set a default value for the state field
+        default="draft", tracking=True  # Set a default value for the state field
     )
+    is_approver = fields.Boolean(compute="_is_approver")
+    is_preparer = fields.Boolean(compute="_is_preparer")
+    is_reviewer = fields.Boolean(compute="_is_reviewer")
+
+    due_date = (datetime.now() + timedelta(days=2)).strftime('%Y-%m-%d')
 
     def save_and_submit(self):
+        if self.state == 'review_rejection':
+            print("In If")
+            self.mark_activity_as_done("Review Reject Items")
         # Your logic for save_and_submit
         self.write({'state': 'review_in_progress'})
         # Trigger the email report function
         self.email_report()
         # Update the state of associated Non-Conformance Records to 'received_vendor_response'
         nc_records = self.mapped('ncr_nc_ids')
+        self._check_nc_table()
         for nc in nc_records:
             nc.write({'state': 'received_vendor_response'})
+        self.create_activity('Review & Approve', 'To Do', self.reviewed_and_approved_by_id.user_id.id, self.due_date)
+
+    def review_approve(self):
+        # Your logic for review
+        self.write({'state': 'approval_pending'})
+        self.create_activity('Approval Pending', 'To Do', self.rca_approver_id.user_id.id, self.due_date)
+        self.mark_activity_as_done("Review & Approve")
 
     def email_report(self):
         # Ensure that this method is called on a single record
@@ -93,38 +120,159 @@ class NcrResponse(models.Model):
 
     def approve_and_forward(self):
         # Your logic for approve_and_forward
-        self.write({'state': 'closed'})
-        return True
+        ncr_id = self.ncr_id
+        nc_records = self.mapped('ncr_nc_ids')
+        for nc in nc_records:
+            if nc.disposition_action == 'accept':
+                nc.write({'state': 'approved'})
+            elif nc.disposition_action == 'reinspect':
+                nc.write({'state': 'return_for_further_actions'})
+        self.show_approve_button = False
+
+        if self.to_reinspect:
+            ncr_id.write({'state': 'return_for_further_actions'})
+            ncr_id.create_activity('Reinspect', 'To Do', ncr_id.ncr_initiator_id.user_id.id, ncr_id.due_date)
+            self.state = 'closed'
+            self.mark_activity_as_done("Approval Pending")
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'success',
+                    'message': 'Notification has been sent to Initiator for reinspect.',
+                    'next': {'type': 'ir.actions.client',
+                             'tag': 'soft_reload', },
+                }
+            }
+        else:
+            ncr_id.write({'state': 'closed'})
+            self.state = 'closed'
+            self.mark_activity_as_done("Approval Pending")
+
 
     def action_rca_rejected(self):
         # Additional logic can be added here if needed
-        return True
+        domain = [
+            ('res_name', '=', self.name),
+            ('user_id', '=', self.env.user.id),
+            ('summary', '=', "Approval Pending"),
+        ]
 
-    @api.depends('ncr_nc_ids.nc_part_details_ids.estimated_backcharge_price')
+        activity = self.env['mail.activity'].search(domain, limit=1)
+        if activity:
+            activity.unlink()
+
+        self.state = "review_rejection"
+        nc_records = self.mapped('ncr_nc_ids')
+        for nc in nc_records:
+            if nc.disposition_action == 'reject':
+                nc.write({'state': 'rejected'})
+        self.create_activity('Review Reject Items', 'To Do', self.rca_approver_id.user_id.id, self.due_date)
+
+    def create_activity(self, summary, activity_type, user_id, date_deadline=None):
+        activity_type_id = self.env['mail.activity.type'].search([('name', '=', activity_type)], limit=1).id
+        if not activity_type_id:
+            # Handle the case where 'To Do' activity type is not found
+            return
+        else:
+            # Create a new activity
+            activity = self.env['mail.activity'].create({
+                'activity_type_id': activity_type_id,
+                'summary': summary,
+                'date_deadline': date_deadline,
+                'res_model_id': self.env['ir.model']._get('x.ncr.response').id,
+                'res_id': self.id,
+                'user_id': user_id,
+            })
+
+            return activity
+
+    def mark_activity_as_done(self, summary):
+
+        domain = [
+            ('res_name', '=', self.name),
+            ('user_id', '=', self.env.user.id),
+            ('summary', '=', summary),
+        ]
+
+        activity = self.env['mail.activity'].search(domain, limit=1)
+
+        if activity:
+            # Mark the activity as done
+            activity.action_feedback()
+
+    def _compute_rca_approver(self):
+        for record in self:
+            record.rca_approver_id = record.ncr_id.ncr_approver_id
+    def _is_reviewer(self):
+        self.is_reviewer = self.env.user == self.reviewed_and_approved_by_id.user_id
+
+    def _is_approver(self):
+        self.is_approver = self.env.user == self.rca_approver_id.user_id
+
+    def _is_preparer(self):
+        self.is_preparer = self.env.user == self.prepared_by_id.user_id
+
+    @api.depends('manual_total_backcharge', 'ncr_nc_ids.nc_part_details_ids.estimated_backcharge_price')
     def _compute_total_backcharge(self):
         for record in self:
-            # Your custom logic for computing total backcharge
-            record.total_backcharge_amount = sum(
-                part.estimated_backcharge_price for part in record.ncr_nc_ids.mapped('nc_part_details_ids')
-            )
+            if record.manual_total_backcharge:
+                record.total_backcharge_amount = record.manual_total_backcharge
+            elif record.total_backcharge_amount == 0.00:
 
-    @api.depends('ncr_nc_ids.nc_part_details_ids.disposition_cost')
+                # Your custom logic for computing total backcharge
+                record.total_backcharge_amount = sum(
+                    part.estimated_backcharge_price for part in record.ncr_nc_ids.mapped('nc_part_details_ids')
+                )
+
+    def _inverse_total_backcharge(self):
+        for record in self:
+            record.manual_total_backcharge = record.total_backcharge_amount
+
+    @api.depends('manual_total_cost_rework', 'ncr_nc_ids.nc_part_details_ids.disposition_cost')
     def _compute_total_cost_for_rework(self):
         for record in self:
-            # Your custom logic for computing total cost for rework
-            record.total_cost_for_rework = sum(
-                part.disposition_cost for part in record.ncr_nc_ids.mapped('nc_part_details_ids')
-            )
+            if record.manual_total_cost_rework:
+                record.total_cost_for_rework = record.manual_total_cost_rework
+            elif record.total_cost_for_rework == 0.00:
+                # Your custom logic for computing total cost for rework
+                record.total_cost_for_rework = sum(
+                    part.disposition_cost for part in record.ncr_nc_ids.mapped('nc_part_details_ids')
+                )
 
-    @api.depends('ncr_nc_ids.ca_response_id', 'ncr_nc_ids.ca_response_id.name')
+    def _inverse_total_cost_rework_editable(self):
+        for record in self:
+            record.manual_total_cost_rework = record.total_cost_for_rework
+
+    @api.depends('ncr_nc_ids.disposition_action')
+    def _compute_to_reinspect(self):
+        for record in self:
+            reinspect_records = record.ncr_nc_ids.filtered(
+                lambda nc: nc.disposition_action == 'reinspect'
+            )
+            record.to_reinspect = False
+            if reinspect_records:
+                record.to_reinspect = True
+
+    @api.depends('ncr_nc_ids.disposition_action')
+    def _compute_to_reject(self):
+        for record in self:
+            reject_records = record.ncr_nc_ids.filtered(
+                lambda nc: nc.disposition_action == 'reject'
+            )
+            record.to_reject = False
+            if reject_records:
+                record.to_reject = True
+
+    @api.depends('ncr_nc_ids.disposition_action')
     def _compute_ncr_completion_status(self):
         for record in self:
             # Filter NCR NC records where ca_response_id has names "CODE-1" or "CODE-2"
-            code_1_2_records = record.ncr_nc_ids.filtered(
-                lambda nc: nc.ca_response_id and nc.ca_response_id.name in ["Code-1", "Code-2"]
+            accept_reinspect_records = record.ncr_nc_ids.filtered(
+                lambda nc: nc.disposition_action == 'accept' or nc.disposition_action == 'reinspect'
             )
             # Calculate the total number of nc_s
-            total_nc_s_count = len(code_1_2_records)
+            total_nc_s_count = len(accept_reinspect_records)
             # Calculate the percentage
             if len(record.ncr_nc_ids) != 0:
                 percentage = (total_nc_s_count / len(record.ncr_nc_ids)) * 100
@@ -137,7 +285,6 @@ class NcrResponse(models.Model):
                     record.show_approve_button = False
             else:
                 record.ncr_completion_status = 0
-
 
     @api.constrains('prepared_by_signature_date', 'reviewed_by_signature_date')
     def _check_fields_size(self):
@@ -163,3 +310,17 @@ class NcrResponse(models.Model):
             else:
                 # Set assigned_to_id to None for other states
                 record.assigned_to_id = None
+
+    @api.onchange('prepared_by_id')
+    def _set_approver_id(self):
+        if self.prepared_by_id.parent_id:
+            self.reviewed_and_approved_by_id = self.prepared_by_id.parent_id
+        else:
+            self.reviewed_and_approved_by_id = None
+
+    def _check_nc_table(self):
+        for record in self:
+            for nc in record.ncr_nc_ids:
+                if not(nc.cause_of_nc_id and nc.disposition_type_id and nc.proposed_due_date and nc.immediate_action):
+                    raise ValidationError('Mandatory fields - Cause of NC, Dispoostion Type, Due date and Immediate Action are required')
+

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -45,12 +45,12 @@
                             <field name="uom"
                                    attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="cause_of_nc_id"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [('state', '!=', 'received_vendor_response')], 'required': [('state', '=', 'received_vendor_response')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
@@ -58,15 +58,15 @@
                                    attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="immediate_action"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
+                                   attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
                                    attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"/>
                             <field name="disposition_type_id"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])], 'required': [('state', '=', 'ncr_submitted')]}"
+                                   attrs="{'readonly': [('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="disposition_action"
-                                   attrs="{'readonly': [ ('state', 'in', ['received_vendor_response', 'approved'])]}"/>
-                            <field name="review_comments"/>
+                                   attrs="{'readonly': [('state', '!=', 'received_vendor_response')]}"/>
+                            <field name="review_comments" attrs="{'readonly': [('state', '!=', 'received_vendor_response')]}"/>
                         </group>
                     </group>
                     <field name="response_attachment_ids" widget="many2many_binary"/>

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -40,37 +40,37 @@
                     <group col="2">
                         <group>
                             <field name="ncr_type_check" invisible="1"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending','closed'])]}"/>
                             <field name="ncr_type_id"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="discipline_id"
-                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"
+                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"
                                    options="{'no_create': True, 'no_create_edit':True}"/>
                             <field name="supplier_name_id"
-                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"
+                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"
                                    options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="purchase_order_no"
-                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="project_number"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="project_name_title"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="tag_no_location"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>
                         <group>
                             <field name="shipment_reference"
-                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="received_date"
-                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','in', ['approval_pending','closed'])]}"/>
+                                   attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="inspection_stage"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="rfi_number"
-                                   attrs="{'readonly': [('state','in', ['approval_pending','closed'])]}"/>/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                         </group>
                     </group>
-                    <field name="ncr_nc_ids">
-                        <tree editable="bottom">
+                    <field name="ncr_nc_ids" options="{'no_create': [('state', '!=', 'new')]}">
+                        <tree editable="bottom" create="attrs.get('create', True)">
                             <field name="nc_s"/>
                             <field name="source_of_nc" options="{'no_create': True, 'no_create_edit': True, 'required': True}" />
                            <field name="nc_description" required="True" />
@@ -86,7 +86,7 @@
                         <group>
                             <field name="ncr_initiator_id"
                                    attrs="{'readonly': [('state','!=', 'new')]}"/>
-                            <field name="ncr_approver_id"/>
+                            <field name="ncr_approver_id" attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="ncr_open_date"
                                    attrs="{'readonly': [('state','!=', 'new')]}"/>
                             <field name="rca_response_due_date"
@@ -102,13 +102,17 @@
                     <field name="is_approver" invisible="True"/>
                     <field name="is_initiator" invisible="True"/>
                     <button string="Save &amp; Forward" type="object" name="save_and_forward"
-                            class="btn-primary col-5" states="new"
+                            class="btn-primary col-5"
                             confirm=" Are you sure want to go with Save &amp; Forward?"
                             attrs="{'invisible': ['|',('is_initiator', '=', False), ('state', '!=', 'new')]}"/>
                     <button string="Approve &amp; Submit" type="object" name="approve_and_submit"
-                            class="btn-primary col-5" states="approval_pending"
+                            class="btn-primary col-5"
                             confirm="Are you sure want to go with Approve &amp; Submit?"
                             attrs="{'invisible': ['|', ('is_approver', '=', False), ('state', '!=', 'approval_pending')]}"/>
+                    <button string="Reinspect Completed" type="object" name="reinspect_completed"
+                            class="btn-primary col-5"
+                            confirm="Are you sure want to mark reinspection as complete?"
+                            attrs="{'invisible': ['|',('is_initiator', '=', False), ('state', '!=', 'return_for_further_actions')]}"/>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -30,9 +30,6 @@
                     <field name="state" widget="statusbar" statusbar_visible="new,closed"/>
                 </header>
                 <sheet>
-                    <h>
-                        <field name="name"/>
-                    </h>
                     <group string="Part-2">
 
                         <field name="ncr_id" readonly="True"/>
@@ -40,87 +37,99 @@
                         <field name="project_number"/>
                         <field name="project_name_title"/>
                     </group>
-                    <field name="ncr_nc_ids" attrs="{'invisible': [('state', 'not in', ['new'])]}">
-                        <tree>
+                    <field name="ncr_nc_ids" attrs="{'invisible': [('state', 'not in', ['new', 'review_in_progress', 'review_rejection'])]}">
+                        <tree create="false">
                             <field name="nc_s"/>
-                            <field name="cause_of_nc_id" attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
+                            <field name="cause_of_nc_id" attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                             <field name="disposition_type_id"/>
                             <field name="immediate_action"
-                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new'])]}"/>
+                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                             <field name="proposed_due_date"
-                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new'])]}"/>
+                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                             <field name="response_attachment_ids"
-                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new'])]}"/>
+                                   attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                             <field name="disposition_action"
-                                   attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                            <field name="review_comments" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                            <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
+                                   attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
+                            <field name="review_comments" attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
+                            <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
                         </tree>
                     </field>
                     <group>
-                        <field name="supplier_response" attrs="{'readonly': [('state', 'not in', ['new'])]}"/>
+                        <field name="supplier_response" attrs="{'readonly': [('state', 'not in', ['new', 'review_rejection'])], 'required': [('state', '=', 'new')], 'invisible': [('state', 'in', ['draft'])]}"/>
                     </group>
                     <group col="2">
                         <group>
-                            <field name="prepared_by_id" attrs="{'readonly': [('state', 'not in', ['new'])]}"/>
+                            <field name="prepared_by_id" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
                             <field name="prepared_by_signature_date"
-                                   attrs="{'readonly': [('state', 'not in', ['new'])]}"/>
+                                   attrs="{'readonly': [('state', 'not in', ['new', 'review_rejection'])], 'required': [('state', 'in', ['new', 'review_rejection'])], 'invisible': [('state', 'in', ['draft'])]}"/>
                             <field name="prepared_by_title"/>
                         </group>
                         <group>
                             <field name="reviewed_and_approved_by_id"
-                                   attrs="{'readonly': [('state', 'not in', ['new'])]}"/>
+                                   attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
                             <field name="reviewed_by_signature_date"
-                                   attrs="{'readonly': [('state', 'not in', ['new'])]}"/>
+                                   attrs="{'readonly': ['|', ('is_reviewer', '=', False), ('state', 'not in', ['review_in_progress'])], 'required': [('state', '=', 'review_in_progress')],'invisible': [('state', 'in', ['draft'])] }"/>
                             <field name="reviewed_by_title"/>
+                        </group>
+                        <group>
+                            <field name="is_approver" invisible="True"/>
+                            <field name="is_preparer" invisible="True"/>
+                            <field name="is_reviewer" invisible="True"/>
                             <button string="Save and Submit" colspan='2'
-                                    attrs="{'invisible': [('state', 'not in', ['new'])]}" type="object"
+                                    attrs="{'invisible': ['|',('is_preparer', '=', False),('state', 'not in', ['new', 'review_rejection'])]}" type="object"
                                     name="save_and_submit"
                                     class="oe_highlight" widget="button"
                                     confirm="Are you sure want to go with Save and Submit?"/>
+                            <button string="Review &amp; Approve" colspan='2'
+                                    attrs="{'invisible': ['|', ('is_reviewer', '=', False), ('state', 'not in', ['review_in_progress'])]}" type="object"
+                                    name="review_approve"
+                                    class="oe_highlight" widget="button"
+                                    confirm="Are you sure want to Approve it?"/>
                         </group>
                     </group>
-                    <group string="Part-3" attrs="{'invisible': [('state', '=', 'new')]}">
+                    <group string="Part-3" attrs="{'invisible': [('state', 'in', ['draft', 'new', 'review_in_progress', 'review_rejection'])]}">
                         <field name="ncr_nc_ids">
-                            <tree>
+                            <tree create="false">
                                 <field name="nc_s"/>
-                                <field name="cause_of_nc_id"
-                                       attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
+                                <field name="cause_of_nc_id" attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                                 <field name="disposition_type_id"/>
                                 <field name="immediate_action"
-                                       attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
+                                       attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                                 <field name="proposed_due_date"
-                                       attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
+                                       attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                                 <field name="response_attachment_ids"
-                                       attrs="{'column_invisible': [('parent.state', '!=', 'new')]}"/>
+                                       attrs="{'column_invisible': [('parent.state', 'not in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'new')]}"/>
                                 <field name="disposition_action"
-                                       attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                                <field name="review_comments"
-                                       attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
-                                <field name="ca_response_id"
-                                       attrs="{'column_invisible': [('parent.state', '=', 'new')]}"/>
+                                       attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
+                                <field name="review_comments" attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
+                                <field name="ca_response_id" attrs="{'column_invisible': [('parent.state', 'in', ['new','review_in_progress', 'review_rejection'])], 'required': [('parent.state', '=', 'approval_pending')]}"/>
                             </tree>
                         </field>
                         <group col="2" attrs="{'invisible': [('state', '=', 'new')]}">
-                            <field name="total_cost_for_rework"/>
+                            <field name="total_cost_for_rework" attrs="{'readonly': [('state', '=', 'closed')]}"/>
                             <field name="rca_approver_id"/>
                             <field name="ncr_completion_status"/>
                             <field name="show_approve_button" invisible="True"/>
-                            <button string="Approve and Forward" colspan='2'
-                                    type="object"
-                                    name="approve_and_forward"
-                                    class="oe_highlight" attrs="{'invisible': [('show_approve_button', '=', False)]}"
-                                    confirm=" Are you sure want to go with Approve and Forward?"/>
+                            <field name="to_reject" invisible="True"/>
+
                         </group>
                         <group attrs="{'invisible': [('state', '=', 'new')]}">
-                            <field name="total_backcharge_amount"/>
+                            <field name="total_backcharge_amount" attrs="{'readonly': [('state', '=', 'closed')]}"/>
                             <field name="title"/>
-                            <field name="ncr_closed_date"/>
-                            <button string="RCA REJECTED" colspan='2'
-                                    type="object"
-                                    name="action_rca_rejected" class="oe_highlight"
-                                    attrs="{'invisible': [('show_approve_button', '=', True)]}"
-                                    confirm="Are you sure want to go with RCA REJECTED?"/>
+                            <field name="ncr_closed_date" attrs="{'required': [('show_approve_button', '=', True)]}"/>
+
+                        </group>
+                        <group>
+                            <button string="Approve and Forward" colspan='2'
+                                        type="object"
+                                        name="approve_and_forward"
+                                        class="oe_highlight" attrs="{'invisible': ['|', ('show_approve_button', '=', False), ('state', '=', 'closed')]}"
+                                        confirm=" Are you sure want to go with Approve and Forward?"/>
+                            <button string="Disposition Rejected" colspan='2'
+                                        type="object"
+                                        name="action_rca_rejected" class="oe_highlight"
+                                        attrs="{'invisible': ['|', ('to_reject', '=', False), ('state', '=', 'closed')]}"
+                                        confirm="Are you sure want to send the rejected items for further review?"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Warning message for NCR Response, Order by month in Dashboard, Fixed the approval workflow in NCR Response

Current behavior before PR: Workflow was not set  for approval and rejection, warning message while start up and graph were not ordered by month

Desired behavior after PR is merged: Proper workflow for NCR and graphs to be ordered by month




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
