### PR TITLE
[FIX] removed reference of ir_rule in Incident module, Location data file update and mandatory fiels in clocation

### DIFF
--- a/custom_addons/aicomsy_base/data/x_location_data.xml
+++ b/custom_addons/aicomsy_base/data/x_location_data.xml
@@ -2,54 +2,88 @@
     <data noupdate="1">
         <record id="l1" model="x.location">
             <field name="name">Plant location - 1</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l2" model="x.location">
             <field name="name">Plant location - 2</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l3" model="x.location">
             <field name="name">Plant location - 3</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l4" model="x.location">
             <field name="name">Plant location - 4</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l5" model="x.location">
             <field name="name">Machine ID-1</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l6" model="x.location">
             <field name="name">Machine ID-2</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l7" model="x.location">
             <field name="name">Machine ID-3</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l8" model="x.location">
             <field name="name">Machine ID-4</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l9" model="x.location">
             <field name="name">Machine ID-5</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l10" model="x.location">
             <field name="name">Warehouse - 1</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l11" model="x.location">
             <field name="name">Warehouse - 2</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l12" model="x.location">
             <field name="name">Warehouse - 3</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l13" model="x.location">
             <field name="name">Manufacturing section - 1</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l14" model="x.location">
             <field name="name">Manufacturing section - 2</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l15" model="x.location">
             <field name="name">Manufacturing section - 3</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l16" model="x.location">
             <field name="name">Manufacturing section - 4</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
         <record id="l17" model="x.location">
             <field name="name">Manufacturing section - 5</field>
+            <field name="location_incharge">1</field>
+            <field name="location_manager">1</field>
         </record>
     </data>
 </odoo>

--- a/custom_addons/aicomsy_base/models/x_location.py
+++ b/custom_addons/aicomsy_base/models/x_location.py
@@ -58,8 +58,8 @@ class Location(models.Model):
         'res.company', 'Company',
         default=lambda self: self.env.company, index=True,
         help='Let this field empty if this location is shared between companies')
-    location_incharge = fields.Many2one('hr.employee', string="Location Incharge")
-    location_manager = fields.Many2one('hr.employee', string="Location Manager")
+    location_incharge = fields.Many2one('hr.employee', string="Location Incharge", required=True)
+    location_manager = fields.Many2one('hr.employee', string="Location Manager", required=True)
     location_alternate_1 = fields.Many2one('hr.employee', string="Alternative Location Manager 1")
     location_alternate_2 = fields.Many2one('hr.employee', string="Alternative Location Manager 2")
     parent_path = fields.Char(index=True, unaccent=False)

--- a/custom_addons/incident_management/__manifest__.py
+++ b/custom_addons/incident_management/__manifest__.py
@@ -9,7 +9,6 @@
     ],
     'data': [
         'security/ir.model.access.csv',
-        'security/ir_rule.xml',
         'data/ir_sequence_data.xml',
         'views/incident_record_views.xml',
         'views/inc_person_views.xml',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Unable to upgrade apps due to change in location constraint

Current behavior before PR: Unable to upgrade the app, ir.rule reference in incident module manifest file. x.location mandatory fields didn't include incharge  and manager.

Desired behavior after PR is merged: Should be able to successfully start the server and locations should be loaded properly




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
