### PR TITLE
[FIX] Remove link for many2one fields in the view, SQl constraints for NCR module, total weight for NC

### DIFF
--- a/custom_addons/incident_management/views/inc_asset_views.xml
+++ b/custom_addons/incident_management/views/inc_asset_views.xml
@@ -27,7 +27,7 @@
                            attrs="{'invisible': [('asset_category', '!=', 'equipment')]}"/>
                     <field name="asset_type"/>
                     <field name="description"/>
-                    <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True}"/>
+                    <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                 </group>
             </form>
         </field>

--- a/custom_addons/incident_management/views/inc_consequences_views.xml
+++ b/custom_addons/incident_management/views/inc_consequences_views.xml
@@ -9,7 +9,7 @@
         <field name="model">x.inc.consequences</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
-                <field name="actions_damages" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="actions_damages" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                 <field name="quantity"/>
                 <field name="unit" options="{'no_create': True, 'no_create_edit':True}"/>
                 <field name="unit_rate"/>

--- a/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
+++ b/custom_addons/incident_management/views/inc_inv_corrective_actions_views.xml
@@ -24,10 +24,10 @@
                                attrs="{'readonly': [('state', '=', 'completed')]}"/>
                         <field name="action_type"
                                attrs="{'invisible': [('state', '=', 'new')], 'required': [('state', 'in', ('in_progress', 'returned'))], 'readonly': [('state', '=', 'completed')]}"
-                               options="{'no_create': True, 'no_create_edit':True}"/>
+                               options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                         <field name="hierarchy_of_control"
                                attrs="{'invisible': [('state', '=', 'new')], 'required': [('state', 'in', ('in_progress', 'returned'))], 'readonly': [('state', '=', 'completed')]}"
-                               options="{'no_create': True, 'no_create_edit':True}"/>
+                               options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                         <field name="proposed_action"
                                attrs="{'invisible': [('state', '=', 'new')], 'required': [('state', 'in', ('in_progress', 'returned'))], 'readonly': [('state', '=', 'completed')]}"/>
                         <field name="target_date"

--- a/custom_addons/incident_management/views/inc_person_views.xml
+++ b/custom_addons/incident_management/views/inc_person_views.xml
@@ -36,7 +36,7 @@
                 <sheet>
                     <group col="2">
                         <group>
-                            <field name="person_category"/>
+                            <field name="person_category" options='{"no_open": True}'/>
                             <field name="employee"
                                    attrs="{'invisible': [('selected_category', 'not in', ('Employee','Contractor'))], 'required': [('selected_category', 'in', ('Employee','Contractor'))]}"/>
                             <field name="visitor_name"
@@ -44,7 +44,7 @@
                             <field name="person_task"/>
                             <field name="immediate_response"
                                    attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="job_title"/>
                             <field name="person_employer"
                                    attrs="{'readonly': [('selected_category', '!=', 'Contractor')]}"/>
@@ -66,8 +66,8 @@
                                    attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
                             <field name="person_days_off"
                                    attrs="{'invisible': [('involved_victim', 'not in', ('victim', 'both'))]}"/>
-                            <field name="oh_incident_classification"/>
-                            <field name="oh_severity_consequence"/>
+                            <field name="oh_incident_classification" options='{"no_open": True}' />
+                            <field name="oh_severity_consequence" options='{"no_open": True}'/>
                             <field name="selected_category" invisible="1"/>
                             <field name="person_name" invisible="1"/>
                         </group>

--- a/custom_addons/incident_management/views/inc_root_causes_views.xml
+++ b/custom_addons/incident_management/views/inc_root_causes_views.xml
@@ -9,7 +9,7 @@
         <field name="model">x.inc.root.causes</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
-                <field name="primary_root_cause_id" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="primary_root_cause_id" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                 <field name="secondary_root_cause_ids" widget='many2many_tags'
                        options="{'no_create': True, 'no_create_edit':True}"/>
                 <field name="comments"/>

--- a/custom_addons/incident_management/views/inc_spills_views.xml
+++ b/custom_addons/incident_management/views/inc_spills_views.xml
@@ -23,16 +23,16 @@
 
                         <group>
                             <field name="env_incident_classification"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="qty"/>
-                            <field name="unit" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="unit" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
 
                         </group>
                         <group>
-                            <field name="env_impact" options="{'no_create': True, 'no_create_edit':True}"/>
+                            <field name="env_impact" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="env_severity_consequence"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
-                            <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
+                            <field name="immediate_response" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                         </group>
                     </group>
                 </sheet>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -40,7 +40,7 @@
                             <field name="severity" attrs="{'invisible': [('state', '!=', 'closed')], 'readonly': [('state', 'not in', ('new', 'investigation_assigned'))]}" options="{'no_create': True, 'no_create_edit': True}" readonly="True"/>
                         </group>
                         <group>
-                            <field name="shift"  attrs="{'readonly': [('state', 'in', 'closed')]}"/>
+                            <field name="shift"  attrs="{'readonly': [('state', 'in', 'closed')]}" options='{"no_open": True}'/>
                             <field name="type" widget="many2many_tags"
                                    options="{'no_create': True, 'no_create_edit':True}" attrs="{'readonly': [('state', 'in', 'closed')]}"/>
                             <field name="location" options="{'no_create': True, 'no_create_edit':True}" attrs="{'readonly': [('state', 'in', 'closed')]}"/>

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -88,7 +88,7 @@ class NonConformanceModel(models.Model):
             ('approved', 'Approved'),
             ('rejected', 'Rejected'),
             ('return_for_further_actions', 'Return for Further Actions'),
-        ], tracking=True,
+        ],
         # Set a default value for the state field
         default='new',
     )
@@ -110,7 +110,9 @@ class NonConformanceModel(models.Model):
 class NCRSource(models.Model):
     _name = 'x.ncr.source'
     _description = 'x NCR Source'
-
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Source of NC must be unique !'),
+    ]
     # Fields for YourModelName
     name = fields.Char(string='Name', required=True)
 
@@ -147,6 +149,9 @@ class NcPartDetails(models.Model):
 class NcrCause(models.Model):
     _name = 'x.ncr.cause'
     _description = 'Cause of NC'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Cause of NC  must be unique !'),
+    ]
 
     name = fields.Char(string='Cause Name', required=True)
 
@@ -154,6 +159,9 @@ class NcrCause(models.Model):
 class NcrDispositionType(models.Model):
     _name = 'x.ncr.disposition.type'
     _description = 'Disposition Type'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Disposition Type must be unique !'),
+    ]
 
     name = fields.Char(string='Disposition Type', required=True)
 
@@ -161,6 +169,9 @@ class NcrDispositionType(models.Model):
 class NcrCaResponse(models.Model):
     _name = 'x.ncr.ca.response'
     _description = 'NCR RCA Response'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'RCA Response must be unique !'),
+    ]
 
     name = fields.Char(string='Name', required=True)
     rca_response = fields.Char(string='Response Type')

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -123,19 +123,25 @@ class NcPartDetails(models.Model):
     # Fields for NcPartDetails
     assembly_number = fields.Char(string='Assembly Number')
     part_number = fields.Char(string='Part Number')
-    unit_weight = fields.Float(string='Unit Weight')
+    unit_weight = fields.Float(string='Unit Weight', default=0)
     affected_part_weight = fields.Float(string='Affected Part Weight')
     completion_percentage = fields.Float(string='% of Completion')
     production_date = fields.Date(string='Production Date')
-    quantity = fields.Float(string='Quantity')
+    quantity = fields.Float(string='Quantity', default=0)
     quarantine = fields.Selection([('yes', 'Yes'), ('no', 'No')], string='Quarantine')
     operator_employee_id = fields.Char(string='Operator / Production Employee ID')
-    total_weight = fields.Float(string='Total Weight')
+    total_weight = fields.Float(string='Total Weight', compute='_calculate_total_weight')
     disposition_priority = fields.Char(string='Disposition Priority')
     disposition_cost = fields.Float(string='Disposition Cost')
     estimated_backcharge_price = fields.Float(string='Estimated Backcharge Price')
     nc_details_id = fields.Many2one('x.ncr.nc', string='NCR Details', required=True, ondelete='cascade')
     ncr_id = fields.Many2one(related="nc_details_id.ncr_id")
+
+    # Compute method to set the value of ncr_list based on the ncr_type
+    @api.depends('unit_weight', 'quantity')
+    def _calculate_total_weight(self):
+        for record in self:
+            record.total_weight = record.unit_weight * record.quantity
 
 
 class NcrCause(models.Model):

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -8,6 +8,9 @@ class NcrReport(models.Model):
     _name = 'x.ncr.report'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = 'NCR Report'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'NCR Id must be unique !'),
+    ]
 
     # Override the create method to set default values and generate a unique name
     @api.model
@@ -231,6 +234,9 @@ class NcrReport(models.Model):
 class NcrType(models.Model):
     _name = 'x.ncr.type'
     _description = 'NCR Type'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'NCR Type must be unique !'),
+    ]
 
     # Fields for NcrType
     name = fields.Char(string='Name', required=True)
@@ -240,7 +246,9 @@ class NcrType(models.Model):
 class Discipline(models.Model):
     _name = 'x.ncr.discipline'
     _description = 'Discipline'
-
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'Supplier Discipline Classification  must be unique !'),
+    ]
     # Fields for Discipline
     name = fields.Char(string='Name', required=True)
 
@@ -249,6 +257,9 @@ class Discipline(models.Model):
 class Category(models.Model):
     _name = 'x.ncr.category'
     _description = 'Category'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'NCR Category must be unique !'),
+    ]
 
     # Fields for Category
     name = fields.Char(string='Name', required=True)

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -7,6 +7,9 @@ class NcrResponse(models.Model):
     _name = 'x.ncr.response'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = 'NCR Response'
+    _sql_constraints = [
+        ('name_uniq', 'unique(name)', 'NCR Response Id must be unique !'),
+    ]
 
     @api.model
     def create(self, vals_list):

--- a/custom_addons/non_conformance_report/static/src/js/dashboard.js
+++ b/custom_addons/non_conformance_report/static/src/js/dashboard.js
@@ -60,7 +60,6 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
                     $('#src_selection').append("<option value=" + ncr_source[src].id + ">" + ncr_source[src].name + "</option>");
                 });
                 var startDateInput = document.getElementById("start_date");
-                var endDateInputt = document.getElementById("end_date");
 
 
                 // Set the value to a specific date (e.g., "2023-06-01")
@@ -69,12 +68,12 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
                 var formattedDate = today.getFullYear() + '-' +
                             ('0' + (today.getMonth() + 1)).slice(-2) + '-' +
                             ('0' + today.getDate()).slice(-2);
-                endDateInputt.value = formattedDate
+                $('#end_date').val(formattedDate)
                 var sixMonthsAgo = new Date();
                 sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
                 sixMonthsAgo.setDate(1);
-                startDateInput.value = sixMonthsAgo.getFullYear() + '-' + ('0' + (sixMonthsAgo.getMonth() + 1)).slice(-2)
-                                    + '-' + ('0' + sixMonthsAgo.getDate()).slice(-2);
+                $('#start_date').val(sixMonthsAgo.getFullYear() + '-' + ('0' + (sixMonthsAgo.getMonth() + 1)).slice(-2)
+                                    + '-' + ('0' + sixMonthsAgo.getDate()).slice(-2));
 
 
             })

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -15,7 +15,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="nc_s"/>
-                <field name="source_of_nc" options="{'no_create': True, 'no_create_edit':True}"/>
+                <field name="source_of_nc" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                 <field name="nc_description"/>
                 <field name="uom"/>
                 <field name="quantity" class="oe_inline"/>
@@ -46,25 +46,25 @@
                                    attrs="{'readonly': [ ('state', 'not in', ['new', 'return_for_further_actions'])]}"/>
                             <field name="cause_of_nc_id"
                                    attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="proposed_due_date"
                                    attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="ca_response_id"
                                    attrs="{'readonly': [('state', '!=', 'received_vendor_response')], 'required': [('state', '=', 'received_vendor_response')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="rca_response"/>
                         </group>
                         <group>
                             <field name="source_of_nc"
                                    attrs="{'readonly': [ ('state', 'in', ['ncr_submitted', 'received_vendor_response', 'approved'])]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="immediate_action"
                                    attrs="{'readonly': [ ('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"/>
                             <field name="quantity" class="oe_inline"
                                    attrs="{'readonly': [ ('state', 'not in', ['new', 'return_for_further_actions'])]}"/>
                             <field name="disposition_type_id"
                                    attrs="{'readonly': [('state', 'not in', ['ncr_submitted', 'rejected'])], 'required': [('state', '=', 'ncr_submitted')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="disposition_action"
                                    attrs="{'readonly': [('state', '!=', 'received_vendor_response')]}"/>
                             <field name="review_comments" attrs="{'readonly': [('state', '!=', 'received_vendor_response')]}"/>

--- a/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_nc_views.xml
@@ -109,17 +109,17 @@
                         <field name="assembly_number"/>
                         <field name="part_number"/>
                         <field name="unit_weight"/>
-                        <field name="affected_part_weight"/>
-                        <field name="completion_percentage"/>
-                        <field name="production_date"/>
                         <field name="quantity"/>
+                        <field name="total_weight"/>
+                        <field name="affected_part_weight"/>
+                        <field name="production_date"/>
                     </group>
                     <group>
                         <field name="operator_employee_id"/>
-                        <field name="total_weight"/>
                         <field name="disposition_priority"/>
                         <field name="disposition_cost"/>
                         <field name="estimated_backcharge_price"/>
+                        <field name="completion_percentage"/>
                         <field name="quarantine" widget="radio" options="{'horizontal': true}" style="display: inline"/>
                     </group>
                 </group>

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -42,10 +42,10 @@
                             <field name="ncr_type_check" invisible="1"
                                    attrs="{'readonly': [('state','not in', ['new', 'approval_pending','closed'])]}"/>
                             <field name="ncr_type_id"
-                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
+                                   attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="discipline_id"
                                    attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                             <field name="supplier_name_id"
                                    attrs="{'invisible': [('ncr_type_check', '=', False)], 'readonly': [('state','not in', ['new', 'approval_pending'])]}"
                                    options="{'no_create': True, 'no_create_edit': True}"/>
@@ -72,7 +72,7 @@
                     <field name="ncr_nc_ids" options="{'no_create': [('state', '!=', 'new')]}">
                         <tree editable="bottom" create="attrs.get('create', True)">
                             <field name="nc_s"/>
-                            <field name="source_of_nc" options="{'no_create': True, 'no_create_edit': True, 'required': True}" />
+                            <field name="source_of_nc" options="{'no_create': True, 'no_create_edit': True, 'no_open': True, 'required': True}" />
                            <field name="nc_description" required="True" />
                             <field name="uom" required="True"/>
                             <field name="quantity" required="True"/>
@@ -96,7 +96,7 @@
                             <field name="initiator_job_title"/>
                             <field name="approver_job_title"/>
                             <field name="ncr_category_id" attrs="{'readonly': [('state', '!=', 'approval_pending')], 'required': [('state','=','approval_pending')]}"
-                                   options="{'no_create': True, 'no_create_edit':True}"/>
+                                   options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
                         </group>
                     </group>
                     <field name="is_approver" invisible="True"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:Link must be available only for few many2one fields, SQL constraints to be added to NCR module, compute total weight for NC, fix null value error in NCR dashboard

Current behavior before PR: Link available for all many2one fields, No unique constraints in NCR module, Manual entry for total weight in NC details, sometimes null error is thrown while access end_date in js for NCR dashboard

Desired behavior after PR is merged: 
Link available only for required many2one fields,
Unique constraint added to NCR module
total_weight is an computational field
use jquery to access end_date and start_date 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
