### PR TITLE
[FIX] NCR - record rules, company specific dashboard, models  to be company specific, company_id as related field in x.ncr.response

### DIFF
--- a/custom_addons/non_conformance_report/__manifest__.py
+++ b/custom_addons/non_conformance_report/__manifest__.py
@@ -6,6 +6,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/ir_rule.xml',
         'data/ir_sequence_data.xml',
         'views/x_ncr_report_views.xml',
         'views/x_ncr_nc_views.xml',

--- a/custom_addons/non_conformance_report/controllers/ncr_dashboard.py
+++ b/custom_addons/non_conformance_report/controllers/ncr_dashboard.py
@@ -7,7 +7,7 @@ from odoo.http import request
 class NCRFilter(http.Controller):
 
     @http.route('/ncr/filter', auth='public', type='json')
-    def ncr_filter(self):
+    def ncr_filter(self, **kw):
         """
 
         Summery:
@@ -18,10 +18,11 @@ class NCRFilter(http.Controller):
 
 
         """
-        location_list =[]
+        location_list = []
         source_list = []
-        location_ids = request.env['x.location'].search([])
-        ncr_source_ids = request.env['x.ncr.source'].search([])
+        company_id = kw.get('params', {}).get('company_id')
+        location_ids = request.env['x.location'].search([('company_id', '=', company_id)])
+        ncr_source_ids = request.env['x.ncr.source'].search([('company_id', '=', company_id)])
         # getting location data
         for location_id in location_ids:
             dic = {'name': location_id.name,

--- a/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_dashboard.py
@@ -12,7 +12,7 @@ class NCRDashboard(models.Model):
     _auto = False
 
     @api.model
-    def get_ncr_by_location(self, start_date, end_date, location,src, ncr):
+    def get_ncr_by_location(self, start_date, end_date, location,src, ncr, currentCompany):
 
         # Your initial query
         base_query = """ SELECT DATE(
@@ -24,7 +24,7 @@ class NCRDashboard(models.Model):
                         LEFT JOIN x_ncr_nc as nc on nc.ncr_id = report.id"""
 
         # Construct the WHERE clause based on conditions
-        conditions = []
+        conditions = [f"report.company_id = '{currentCompany}'"]
         if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
             conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
 
@@ -58,7 +58,7 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_ncr_source_classification(self, start_date, end_date, location, src, ncr):
+    def get_ncr_source_classification(self, start_date, end_date, location, src, ncr, currentCompany):
         # Your initial query
         base_query = """SELECT  DATE(
                                 TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
@@ -70,7 +70,7 @@ class NCRDashboard(models.Model):
                 LEFT JOIN x_ncr_source  as src ON nc.source_of_nc = src.id"""
 
         # Construct the WHERE clause based on conditions
-        conditions = []
+        conditions = [f"report.company_id = '{currentCompany}'"]
         if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
             conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
 
@@ -106,7 +106,7 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_cost_of_rework(self, start_date, end_date, location, src, ncr):
+    def get_cost_of_rework(self, start_date, end_date, location, src, ncr, currentCompany):
         # Your initial query
         base_query = """SELECT  DATE(
                             TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
@@ -118,7 +118,7 @@ class NCRDashboard(models.Model):
                     LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id"""
 
         # Construct the WHERE clause based on conditions
-        conditions = []
+        conditions = [f"report.company_id = '{currentCompany}'"]
         if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
             conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
 
@@ -155,7 +155,7 @@ class NCRDashboard(models.Model):
         return {'labels': labels, 'data': data, 'classification': classification}
 
     @api.model
-    def get_customer_backcharges(self, start_date, end_date, location, src, ncr):
+    def get_customer_backcharges(self, start_date, end_date, location, src, ncr, currentCompany):
         # Your initial query
         base_query = """SELECT  DATE(
                                 TO_CHAR(ncr_open_date, 'YYYY') || '-' || 
@@ -166,7 +166,7 @@ class NCRDashboard(models.Model):
                             LEFT JOIN x_ncr_part AS part ON nc.id = part.nc_details_id"""
 
         # Construct the WHERE clause based on conditions
-        conditions = []
+        conditions = [f"report.company_id = '{currentCompany}'"]
         if (start_date is not None and start_date != '') and (end_date is not None and end_date != ''):
             conditions.append(f"ncr_open_date BETWEEN '{start_date}'  AND  '{end_date}'")
 

--- a/custom_addons/non_conformance_report/models/x_ncr_nc.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_nc.py
@@ -111,10 +111,11 @@ class NCRSource(models.Model):
     _name = 'x.ncr.source'
     _description = 'x NCR Source'
     _sql_constraints = [
-        ('name_uniq', 'unique(name)', 'Source of NC must be unique !'),
+        ('name_uniq', 'unique(name, company_id)', 'Source of NC must be unique !'),
     ]
     # Fields for YourModelName
     name = fields.Char(string='Name', required=True)
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
 
 
 # Define NcPartDetails class

--- a/custom_addons/non_conformance_report/models/x_ncr_response.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_response.py
@@ -31,7 +31,7 @@ class NcrResponse(models.Model):
     name = fields.Char(string="NCR Reference", default='New', readonly=True)
     ncr_type_id = fields.Many2one('x.ncr.type', related="ncr_id.ncr_type_id", string='NCR Type')
     ncr_id = fields.Many2one("x.ncr.report", string='NCR No.')
-    company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company)
+    company_id = fields.Many2one(related="ncr_id.company_id")
     project_number = fields.Char(related="ncr_id.project_number", string='Project Number')
     project_name_title = fields.Char(related="ncr_id.project_name_title", string='Project Name / Title')
     supplier_response = fields.Text(string='Supplier Response', tracking=True)

--- a/custom_addons/non_conformance_report/security/ir_rule.xml
+++ b/custom_addons/non_conformance_report/security/ir_rule.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <record model="ir.rule" id="aicomsy_ncr_report">
+        <field name="name">NCR Report company rule</field>
+        <field name="model_id" ref="non_conformance_report.model_x_ncr_report"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', '=', company_id)]</field>
+    </record>
+   <record model="ir.rule" id="aicomsy_ncr_response">
+        <field name="name">NCR Response company rule</field>
+        <field name="model_id" ref="non_conformance_report.model_x_ncr_response"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', '=', company_id)]</field>
+    </record>
+</odoo>

--- a/custom_addons/non_conformance_report/static/src/js/dashboard.js
+++ b/custom_addons/non_conformance_report/static/src/js/dashboard.js
@@ -10,6 +10,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
     var web_client = require('web.web_client');
     // Declare an array to store chart instances
     var chartInstances = [];
+    var currentCompany;
     var NCRDashboard = AbstractAction.extend({
         template: 'NCRDashboard',
         events: {
@@ -30,6 +31,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
             var self = this;
             this.set("title", 'Dashboard');
             return this._super().then(function() {
+                currentCompany = session.user_context.allowed_company_ids[0];
                 self.render_dashboards();
                 self.render_graphs();
                 self.render_filter();
@@ -50,9 +52,13 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
         function for getting values to the filters
         */
         render_filter: function() {
-            ajax.rpc('/ncr/filter').then(function(data) {
-                var locations = data[0]
-                var ncr_source =data[1]
+            ajax.rpc('/ncr/filter', {
+                'params': {
+                    'company_id': currentCompany,
+                },
+                }).then(function(data) {
+                var locations = data[0];
+                var ncr_source =data[1];
                 $(locations).each(function(location) {
                     $('#locations_selection').append("<option value=" + locations[location].id + ">" + locations[location].name + "</option>");
                 });
@@ -313,7 +319,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
              rpc.query({
                          model: "x.ncr.dashboard",
                          method: 'get_ncr_by_location',
-                         args: [start_date, end_date, location,src_selection, ncr_selection],
+                         args: [start_date, end_date, location,src_selection, ncr_selection, currentCompany],
                     }).then(function(data) {
                         var classificationColors = {
                             'Plant location - 1': '#ef9b20',
@@ -338,7 +344,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_ncr_source_classification',
-                        args: [start_date, end_date, location, src_selection, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection, currentCompany],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',
@@ -363,7 +369,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_cost_of_rework',
-                        args: [start_date, end_date, location, src_selection, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection, currentCompany],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',
@@ -388,7 +394,7 @@ odoo.define('noncr_dashboard.Dashboard', function(require) {
              rpc.query({
                         model: "x.ncr.dashboard",
                         method: 'get_customer_backcharges',
-                        args: [start_date, end_date, location, src_selection, ncr_selection],
+                        args: [start_date, end_date, location, src_selection, ncr_selection, currentCompany],
                     }).then(function(data) {
                         var classificationColors = {
                             'Material': '#ef9b20',

--- a/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_lov_views.xml
@@ -96,6 +96,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="name"/>
+                <field name="company_id"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -12,6 +12,7 @@
                 <field name="name"/>
                 <field name="ncr_type_id"/>
                 <field name="project_name_title"/>
+                <field name="company_id"/>
                 <field name="tag_no_location"/>
                 <field name="state"/>
                 <field name="assigned_to_id"/>
@@ -39,7 +40,6 @@
                     </h1>
                     <group col="2">
                         <group>
-                            <field name="company_id" invisible="1"/>
                             <field name="ncr_type_check" invisible="1"/>
                             <field name="ncr_type_id"
                                    attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True, 'no_open': True}"/>
@@ -55,6 +55,7 @@
                                    attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
                             <field name="project_name_title"
                                    attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}"/>
+                            <field name="company_id"/>
                             <field name="tag_no_location"
                                    attrs="{'readonly': [('state','not in', ['new', 'approval_pending'])]}" options="{'no_create': True, 'no_create_edit':True}"/>
                         </group>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -11,6 +11,8 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="ncr_id"/>
+                <field name="name"/>
+                <field name="company_id"/>
                 <field name="ncr_type_id"/>
                 <field name="project_name_title"/>
                 <field name="project_number"/>
@@ -37,6 +39,7 @@
                     <group string="Response To NCR">
 
                         <field name="ncr_id" readonly="True"/>
+                        <field name="company_id"/>
                         <field name="ncr_type_id"/>
                         <field name="project_number"/>
                         <field name="project_name_title"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: NCR module was not compatable with multi company

Current behavior before PR:

Desired behavior after PR is merged:

[FIX] record rules, company specific dashboard, models  to be company specific, company_id as related field in x.ncr.response

Company specific models include : x.ncr.source, x.ncr.report, x.ncr.response


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
