### PR TITLE
[FIX] In NCR Report model added res.users, In  Investigation,Incident, NCR Report, Ncr Response views state colour had been added

### DIFF
--- a/custom_addons/incident_management/views/inc_investigation_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_views.xml
@@ -13,6 +13,8 @@
                 <field name="name"/>
                 <field name="incident_id"/>
                 <field name="description"/>
+                <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
+                <field name="activity_ids" widget="list_activity"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/inc_investigation_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_views.xml
@@ -15,6 +15,7 @@
                 <field name="description"/>
                 <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
                 <field name="activity_ids" widget="list_activity"/>
+                <field name="state"  decoration-success="state == 'closed'" decoration-warning="state in ['assigned', 'in_progress']" widget="badge"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/inc_investigation_views.xml
+++ b/custom_addons/incident_management/views/inc_investigation_views.xml
@@ -15,7 +15,7 @@
                 <field name="description"/>
                 <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
                 <field name="activity_ids" widget="list_activity"/>
-                <field name="state"  decoration-success="state == 'closed'" decoration-warning="state in ['assigned', 'in_progress']" widget="badge"/>
+                <field name="state"  decoration-info="state == 'assigned'" decoration-success="state == 'closed'" decoration-warning="state =='in_progress'" widget="badge"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/incident_management/views/incident_record_views.xml
+++ b/custom_addons/incident_management/views/incident_record_views.xml
@@ -14,7 +14,9 @@
                 <field name="inc_reported_date"/>
                 <field name="type" widget="many2many_tags"/>
                 <field name="location"/>
-                <field name="state"/>
+                <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
+                <field name="activity_ids" widget="list_activity"/>
+                <field name="state" decoration-info="state == 'new'" decoration-success="state == 'closed'" decoration-warning="state in ['investigation_assigned', 'investigation_in_progress', 'action_review']" decoration-danger="state in ['canceled']" widget="badge"/>
             </tree>
         </field>
     </record>

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -29,15 +29,20 @@ class NcrReport(models.Model):
     purchase_order_no = fields.Char(string='Purchase Order No.')
     project_number = fields.Char(string='Project Number', required=True)
     project_name_title = fields.Char(string='Project Name / Title')
-    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location", domain="[('company_id', '=', company_id)]", required=True)
+    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location",
+                                      domain="[('company_id', '=', company_id)]", required=True)
     shipment_reference = fields.Char(string='Shipment Reference')
     received_date = fields.Date(string='Received Date')
     inspection_stage = fields.Char(string='Inspection Stage')
     rfi_number = fields.Char(string='RFI Number')
-    ncr_initiator_id = fields.Many2one('res.users', string='NCR Initiator Name', required=True,default=lambda self: self.env.user.id if self.env.user else False,domain="[('company_id', '=', company_id)]", tracking=True)
+    ncr_initiator_id = fields.Many2one('res.users', string='NCR Initiator Name', required=True,
+                                       default=lambda self: self.env.user.id if self.env.user else False,
+                                       domain="[('company_id', '=', company_id)]", tracking=True)
     initiator_job_title = fields.Char(string="Initiator Job Title", store=True)
-    ncr_open_date = fields.Date(string='NCR Open Date', required=True, default=fields.Date.context_today, copy=False,tracking=True)
-    ncr_approver_id = fields.Many2one('res.users', string='NCR Approver Name', store=True,domain="[('company_id', '=', company_id)]", tracking=True)
+    ncr_open_date = fields.Date(string='NCR Open Date', required=True, default=fields.Date.context_today, copy=False,
+                                tracking=True)
+    ncr_approver_id = fields.Many2one('res.users', string='NCR Approver Name', store=True,
+                                      domain="[('company_id', '=', company_id)]", tracking=True)
     approver_job_title = fields.Char(related='ncr_approver_id.employee_id.job_id.name', string="Job Title", store=True)
     rca_response_due_date = fields.Date(string='RCA Response Due Date', copy=False)
     ncr_category_id = fields.Many2one(comodel_name='x.ncr.category', string='NCR Category', copy=False)
@@ -81,7 +86,8 @@ class NcrReport(models.Model):
             if self.ncr_initiator_id.employee_id:
                 manager = self.ncr_initiator_id.employee_id.parent_id.user_id if self.ncr_initiator_id.employee_id.parent_id else False
                 self.ncr_approver_id = manager
-                self.approver_job_title = manager.employee_id.job_id.name if manager and manager.employee_id.job_id else "No Job Title"
+                if manager.employee_id:
+                    self.approver_job_title = manager.employee_id.job_id.name if manager.employee_id.job_id else "No Job Title"
             else:
                 self.ncr_approver_id = False
                 self.approver_job_title = False
@@ -99,6 +105,7 @@ class NcrReport(models.Model):
         for record in self:
             if not record.ncr_nc_ids:
                 raise ValidationError('At least one Non-Conformance record is required in the Table')
+
     # Compute method to set the value of ncr_list based on the ncr_type
     @api.depends('ncr_type_id')
     def _compute_ncr_type_check(self):
@@ -132,7 +139,8 @@ class NcrReport(models.Model):
         mail_template.send_mail(self.id, force_send=True)
         self.mark_activity_as_done("Approval Pending")
         if self.tag_no_location.location_incharge.user_id.id:
-            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id, self.due_date)
+            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id,
+                                 self.due_date)
         self.write({'state': 'approved'})
 
         # Update the state of associated Non-Conformance Records to 'ncr_submitted'
@@ -141,14 +149,12 @@ class NcrReport(models.Model):
         for nc in nc_records:
             nc.write({'state': 'ncr_submitted'})
 
-
     def reinspect_completed(self):
         nc_records = self.mapped('ncr_nc_ids')
         for nc in nc_records:
             if nc.disposition_action == 'reinspect':
                 nc.write({'state': 'ncr_submitted'})
         self.state = "closed"
-
 
     def add_supplier(self):
         # Open a form to add a new supplier

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -68,8 +68,8 @@ class NcrReport(models.Model):
     @api.onchange('ncr_initiator_id')
     def _onchange_ncr_initiator_id(self):
         if self.ncr_initiator_id:
-            if self.ncr_initiator_id:
-                self.initiator_job_title = self.ncr_initiator_id.employee_id.job_id.name if self.ncr_initiator_id.employee_id else "No Job Title"
+            if self.ncr_initiator_id.employee_id:
+                self.initiator_job_title = self.ncr_initiator_id.employee_id.job_id.name if self.ncr_initiator_id.employee_id.job_id else "No Job Title"
             else:
                 self.initiator_job_title = "No Job Title"
         else:
@@ -78,12 +78,13 @@ class NcrReport(models.Model):
     @api.onchange('ncr_initiator_id')
     def _set_approver_id(self):
         if self.ncr_initiator_id:
-            manager = self.ncr_initiator_id.employee_id.parent_id.user_id if self.ncr_initiator_id.employee_id.parent_id else False
-            self.ncr_approver_id = manager
-            self.approver_job_title = manager.employee_id.job_id.name if manager and manager.employee_id else "No Job Title"
-        else:
-            self.ncr_approver_id = False
-            self.approver_job_title = False
+            if self.ncr_initiator_id.employee_id:
+                manager = self.ncr_initiator_id.employee_id.parent_id.user_id if self.ncr_initiator_id.employee_id.parent_id else False
+                self.ncr_approver_id = manager
+                self.approver_job_title = manager.employee_id.job_id.name if manager and manager.employee_id.job_id else "No Job Title"
+            else:
+                self.ncr_approver_id = False
+                self.approver_job_title = False
 
     def _is_location_incharge(self):
         self.is_location_incharge = self.env.user == self.tag_no_location.location_incharge.user_id

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -134,7 +134,7 @@ class NcrReport(models.Model):
         self.mark_activity_as_done("Approval Pending")
         if self.tag_no_location.location_incharge.user_id.id:
             self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id, self.due_date)
-            self.write({'state': 'approved'})
+        self.write({'state': 'approved'})
 
         # Update the state of associated Non-Conformance Records to 'ncr_submitted'
         nc_records = self.mapped('ncr_nc_ids')

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -48,7 +48,7 @@ class NcrReport(models.Model):
     assigned_to_id = fields.Many2one('hr.employee', string='Assigned to', compute='_compute_assignee')
     is_location_incharge = fields.Boolean(compute="_is_location_incharge")
     is_approver = fields.Boolean(compute="_is_approver")
-    is_initiator = fields.Boolean(compute="_is_initiator")    
+    is_initiator = fields.Boolean(compute="_is_initiator")
     # State field for the NcrReport
     state = fields.Selection(
         selection=[
@@ -60,7 +60,7 @@ class NcrReport(models.Model):
             ('rejected', 'Rejected'),
             ('return_for_further_actions', 'Return for Further Actions'),
             ('closed', 'Closed')
-        ], tracking=True, default ='new'
+        ], tracking=True, default='new', string='Status'
         # Set a default value for the state field
     )
 

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -29,7 +29,7 @@ class NcrReport(models.Model):
     purchase_order_no = fields.Char(string='Purchase Order No.')
     project_number = fields.Char(string='Project Number', required=True)
     project_name_title = fields.Char(string='Project Name / Title')
-    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location",domain="[('company_id', '=', company_id)]", required=True)
+    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location", domain="[('company_id', '=', company_id)]", required=True)
     shipment_reference = fields.Char(string='Shipment Reference')
     received_date = fields.Date(string='Received Date')
     inspection_stage = fields.Char(string='Inspection Stage')
@@ -100,8 +100,6 @@ class NcrReport(models.Model):
         for record in self:
             if not record.ncr_nc_ids:
                 raise ValidationError('At least one Non-Conformance record is required in the Table')
-
-
     # Compute method to set the value of ncr_list based on the ncr_type
     @api.depends('ncr_type_id')
     def _compute_ncr_type_check(self):
@@ -135,8 +133,8 @@ class NcrReport(models.Model):
         mail_template.send_mail(self.id, force_send=True)
         self.mark_activity_as_done("Approval Pending")
         if self.tag_no_location.location_incharge.user_id.id:
-            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id,self.due_date)
-        self.write({'state': 'approved'})
+            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id, self.due_date)
+            self.write({'state': 'approved'})
 
         # Update the state of associated Non-Conformance Records to 'ncr_submitted'
         nc_records = self.mapped('ncr_nc_ids')
@@ -144,12 +142,14 @@ class NcrReport(models.Model):
         for nc in nc_records:
             nc.write({'state': 'ncr_submitted'})
 
+
     def reinspect_completed(self):
         nc_records = self.mapped('ncr_nc_ids')
         for nc in nc_records:
             if nc.disposition_action == 'reinspect':
                 nc.write({'state': 'ncr_submitted'})
         self.state = "closed"
+
 
     def add_supplier(self):
         # Open a form to add a new supplier

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -29,20 +29,15 @@ class NcrReport(models.Model):
     purchase_order_no = fields.Char(string='Purchase Order No.')
     project_number = fields.Char(string='Project Number', required=True)
     project_name_title = fields.Char(string='Project Name / Title')
-    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location",
-                                      domain="[('company_id', '=', company_id)]", required=True)
+    tag_no_location = fields.Many2one("x.location", string="Tag No. / Location",domain="[('company_id', '=', company_id)]", required=True)
     shipment_reference = fields.Char(string='Shipment Reference')
     received_date = fields.Date(string='Received Date')
     inspection_stage = fields.Char(string='Inspection Stage')
     rfi_number = fields.Char(string='RFI Number')
-    ncr_initiator_id = fields.Many2one('res.users', string='NCR Initiator Name', required=True,
-                                       default=lambda self: self.env.user.id if self.env.user else False,
-                                       domain="[('company_id', '=', company_id)]", tracking=True)
+    ncr_initiator_id = fields.Many2one('res.users', string='NCR Initiator Name', required=True,default=lambda self: self.env.user.id if self.env.user else False,domain="[('company_id', '=', company_id)]", tracking=True)
     initiator_job_title = fields.Char(string="Initiator Job Title", store=True)
-    ncr_open_date = fields.Date(string='NCR Open Date', required=True, default=fields.Date.context_today, copy=False,
-                                tracking=True)
-    ncr_approver_id = fields.Many2one('res.users', string='NCR Approver Name', store=True,
-                                      domain="[('company_id', '=', company_id)]", tracking=True)
+    ncr_open_date = fields.Date(string='NCR Open Date', required=True, default=fields.Date.context_today, copy=False,tracking=True)
+    ncr_approver_id = fields.Many2one('res.users', string='NCR Approver Name', store=True,domain="[('company_id', '=', company_id)]", tracking=True)
     approver_job_title = fields.Char(related='ncr_approver_id.employee_id.job_id.name', string="Job Title", store=True)
     rca_response_due_date = fields.Date(string='RCA Response Due Date', copy=False)
     ncr_category_id = fields.Many2one(comodel_name='x.ncr.category', string='NCR Category', copy=False)
@@ -106,6 +101,7 @@ class NcrReport(models.Model):
             if not record.ncr_nc_ids:
                 raise ValidationError('At least one Non-Conformance record is required in the Table')
 
+
     # Compute method to set the value of ncr_list based on the ncr_type
     @api.depends('ncr_type_id')
     def _compute_ncr_type_check(self):
@@ -139,8 +135,7 @@ class NcrReport(models.Model):
         mail_template.send_mail(self.id, force_send=True)
         self.mark_activity_as_done("Approval Pending")
         if self.tag_no_location.location_incharge.user_id.id:
-            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id,
-                                 self.due_date)
+            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id,self.due_date)
         self.write({'state': 'approved'})
 
         # Update the state of associated Non-Conformance Records to 'ncr_submitted'

--- a/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_report_views.xml
@@ -14,7 +14,9 @@
                 <field name="project_name_title"/>
                 <field name="company_id"/>
                 <field name="tag_no_location"/>
-                <field name="state"/>
+                <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
+                <field name="activity_ids" widget="list_activity"/>
+                <field name="state" decoration-info="state == 'new'" decoration-success="state == 'closed'" decoration-warning="state in ['approval_pending', 'approved', 'awaiting_vendor_response', 'received_vendor_response', 'rejected', 'return_for_further_actions']" widget="badge"/>
                 <field name="assigned_to_id"/>
             </tree>
         </field>

--- a/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
+++ b/custom_addons/non_conformance_report/views/x_ncr_response_views.xml
@@ -16,7 +16,9 @@
                 <field name="ncr_type_id"/>
                 <field name="project_name_title"/>
                 <field name="project_number"/>
-                <field name="state"/>
+                <field name="activity_date_deadline" string="Due Date" widget="remaining_days"/>
+                <field name="activity_ids" widget="list_activity"/>
+                <field name="state" decoration-info="state == 'new'" decoration-success="state == 'closed'" decoration-warning="state in ['review_in_progress', 'approval_pending', 'review_rejection']" widget="badge"/>
                 <field name="assigned_to_id"/>
             </tree>
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:   In model Report
 status had been added, In  Investigation,Incident, NCR Report, Ncr Response views state colour had been added and in tree view activity and due date had been added, In NCR Report model had been added res.users for initiator_id and approver_id,removed related field in initiator_job title and added on change for ncr_initiator_id
 
Current behavior before PR: state colour not viewed, hr.employee used

Desired behavior after PR is merged: state colour had been added , Instead of  hr.employee used res.users




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
