### PR TITLE
[FIX] In x_location.py,x_ncr_report.py and x_inc_investigation.py added res.users

### DIFF
--- a/custom_addons/aicomsy_base/models/x_location.py
+++ b/custom_addons/aicomsy_base/models/x_location.py
@@ -58,10 +58,10 @@ class Location(models.Model):
         'res.company', 'Company',
         default=lambda self: self.env.company, index=True,
         help='Let this field empty if this location is shared between companies')
-    location_incharge = fields.Many2one('hr.employee', string="Location Incharge", required=True)
-    location_manager = fields.Many2one('hr.employee', string="Location Manager", required=True)
-    location_alternate_1 = fields.Many2one('hr.employee', string="Alternative Location Manager 1")
-    location_alternate_2 = fields.Many2one('hr.employee', string="Alternative Location Manager 2")
+    location_incharge = fields.Many2one('res.users', string="Location Incharge", required=True, domain="[('company_id', '=', company_id)]")
+    location_manager = fields.Many2one('res.users', string="Location Manager", required=True, domain="[('company_id', '=', company_id)]")
+    location_alternate_1 = fields.Many2one('res.users', string="Alternative Location Manager 1", domain="[('company_id', '=', company_id)]")
+    location_alternate_2 = fields.Many2one('res.users', string="Alternative Location Manager 2", domain="[('company_id', '=', company_id)]")
     parent_path = fields.Char(index=True, unaccent=False)
 
     @api.depends('name', 'location_id.complete_name')

--- a/custom_addons/incident_management/data/mail_template_data.xml
+++ b/custom_addons/incident_management/data/mail_template_data.xml
@@ -6,7 +6,7 @@
                    ref="incident_management.model_x_incident_record"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.location.location_manager.work_email}},{{object.location.location_alternate_1.work_email}},{{object.location.location_alternate_2.work_email}}
+                {{object.location.location_manager.employee_id.work_email}},{{object.location.location_alternate_1.employee_id.work_email}},{{object.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">{{object.name}}</field>
             <field name="body_html" type="html">
@@ -58,7 +58,7 @@
                    ref="incident_management.model_x_inc_investigation"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.hse_officer.work_email}},{{object.field_executive.work_email}},{{object.hr_administration.work_email}},{{', '.join([employee.employee.work_email for employee in object.investigation_team if employee.employee and employee.employee.work_email]) }},{{object.incident_id.location.location_manager.work_email}},{{object.incident_id.location.location_alternate_1.work_email}},{{object.incident_id.location.location_alternate_2.work_email}}
+                {{object.hse_officer.work_email}},{{object.field_executive.work_email}},{{object.hr_administration.work_email}},{{', '.join([employee.employee.work_email for employee in object.investigation_team if employee.employee and employee.employee.work_email]) }},{{object.incident_id.location.location_manager.employee_id.work_email}},{{object.incident_id.location.location_alternate_1.employee_id.work_email}},{{object.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject"> Incident {{object.incident_id.name}} - Closed with Severity {{object.severity.name}} </field>
             <field name="body_html" type="html">
@@ -152,7 +152,7 @@
                    ref="incident_management.model_x_inc_root_causes"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+                {{object.investigation_id.incident_id.location.location_manager.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">Assigned - Root Cause for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -196,7 +196,7 @@
                    ref="incident_management.model_x_inc_inv_corrective_actions"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+                {{object.investigation_id.incident_id.location.location_manager.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">Assigned - Corrective Action for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -251,7 +251,7 @@
                    ref="incident_management.model_x_inc_inv_corrective_actions"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+                {{object.investigation_id.incident_id.location.location_manager.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">Review - Corrective Action for {{object.investigation_id.name}} - {{object.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -420,7 +420,7 @@
                    ref="incident_management.model_x_inc_inv_action_review"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.corrective_action_id.action_party.work_email}},{{object.investigation_id.incident_id.location.location_manager.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+                {{object.corrective_action_id.action_party.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_manager.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_1.employee_id.work_email}},{{object.investigation_id.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">Returned - Corrective Action for {{object.investigation_id.name}} - {{object.corrective_action_id.primary_root_cause_id.name}}</field>
             <field name="body_html" type="html">
@@ -599,9 +599,9 @@
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
                 {{object.investigation_id.hse_officer.work_email}},{{object.investigation_id.field_executive.work_email}},
-                {{object.investigation_id.hr_administration.work_email}},{{object.investigation_id.incident_id.location.location_manager.work_email}},
-                {{object.investigation_id.incident_id.location.location_alternate_1.work_email}},
-                {{object.investigation_id.incident_id.location.location_alternate_2.work_email}}
+                {{object.investigation_id.hr_administration.work_email}},{{object.investigation_id.incident_id.location.location_manager.employee_id.work_email}},
+                {{object.investigation_id.incident_id.location.location_alternate_1.employee_id.work_email}},
+                {{object.investigation_id.incident_id.location.location_alternate_2.employee_id.work_email}}
             </field>
             <field name="subject">Closure of  {{object.investigation_id.name}} - {{object.investigation_id.incident_id.name}}</field>
             <field name="body_html" type="html">

--- a/custom_addons/incident_management/models/x_inc_investigation.py
+++ b/custom_addons/incident_management/models/x_inc_investigation.py
@@ -362,8 +362,8 @@ class CorrectiveAction(models.Model):
     action_type = fields.Many2one('x.inc.inv.ca.action.type', string="Action Type", help='Action Type')
     hierarchy_of_control = fields.Many2one('x.inc.inv.ca.hierarchy.control', string="Hierarchy of Control",
                                            help='Hierarchy of Control')
-    action_party = fields.Many2one('hr.employee', string="Action Party", help='Action Party', domain="[('company_id', '=', company_id)]")
-    assigner = fields.Many2one('hr.employee', string="Assigner", help='Assigner', domain="[('company_id', '=', company_id)]")
+    action_party = fields.Many2one('res.users', string="Action Party", help='Action Party', domain="[('company_id', '=', company_id)]")
+    assigner = fields.Many2one('res.users', string="Assigner", help='Assigner', domain="[('company_id', '=', company_id)]")
     target_date = fields.Date(string="Target Date of Completion", help='Target Date of Completion')
     remarks = fields.Text(string="Remarks")
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string="Attachments")

--- a/custom_addons/non_conformance_report/data/mail_template_data.xml
+++ b/custom_addons/non_conformance_report/data/mail_template_data.xml
@@ -6,7 +6,7 @@
                    ref="non_conformance_report.model_x_ncr_report"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.tag_no_location.location_incharge.work_email}}
+                {{object.tag_no_location.location_incharge.employee_id.work_email}}
             </field>
             <field name="subject">{{object.name}}</field>
             <field name="body_html" type="html">
@@ -23,7 +23,7 @@
                    ref="non_conformance_report.model_x_ncr_report"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.ncr_initiator_id.work_email}},{{object.ncr_approver_id.work_email}}
+                {{object.ncr_initiator_id.work_email}},{{object.ncr_approver_id.employee_id.work_email}}
             </field>
             <field name="subject">{{object.name}}</field>
             <field name="body_html" type="html">
@@ -71,7 +71,7 @@
                    ref="non_conformance_report.model_x_ncr_response"/>
             <field name="email_from">aicomsy.alerts@gmail.com</field>
             <field name="email_to">
-                {{object.prepared_by_id.work_email}},{{object.reviewed_and_approved_by_id.work_email}}
+                {{object.prepared_by_id.work_email}},{{object.reviewed_and_approved_by_id.employee_id.work_email}}
             </field>
             <field name="subject">{{object.name}}</field>
             <field name="body_html" type="html">

--- a/custom_addons/non_conformance_report/models/x_ncr_report.py
+++ b/custom_addons/non_conformance_report/models/x_ncr_report.py
@@ -88,7 +88,7 @@ class NcrReport(models.Model):
                 self.approver_job_title = False
 
     def _is_location_incharge(self):
-        self.is_location_incharge = self.env.user == self.tag_no_location.location_incharge.user_id
+        self.is_location_incharge = self.env.user == self.tag_no_location.location_incharge
 
     def _is_initiator(self):
         self.is_initiator = self.env.user == self.ncr_initiator_id
@@ -132,8 +132,8 @@ class NcrReport(models.Model):
         # Send approval email and force_send=True ensures the email is sent immediately
         mail_template.send_mail(self.id, force_send=True)
         self.mark_activity_as_done("Approval Pending")
-        if self.tag_no_location.location_incharge.user_id.id:
-            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.user_id.id, self.due_date)
+        if self.tag_no_location.location_incharge.id:
+            self.create_activity('Assign Response Handler', 'To Do', self.tag_no_location.location_incharge.id, self.due_date)
         self.write({'state': 'approved'})
 
         # Update the state of associated Non-Conformance Records to 'ncr_submitted'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  In x_location.py,x_ncr_report.py and x_inc_investigation.py added res.users and In mail_template_data.xml for incident and ncr had been added employee_id which are linked in res.users

Current behavior before PR:   not res.users added

Desired behavior after PR is merged:
res.users had been added




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
