### PR TITLE
[FIX] In mail_template_data.xml, x_legal_regulation.py, x_monitoring_measurement.py, legal_register_menu.xml, x_legal_regulation_views.xml, x_monitoring_measurement_views.xml changes had been added 

### DIFF
--- a/custom_addons/legal_compliance_management/data/mail_template_data.xml
+++ b/custom_addons/legal_compliance_management/data/mail_template_data.xml
@@ -110,7 +110,7 @@
                                 </li>
                                 <li>
                                     <strong>Test Performed on:</strong>
-                                    <t t-out="object.date_time"/>
+                                    <t t-out="object.test_performed_on"/>
                                 </li>
                                 <li>
                                     <strong>Test Result:</strong>
@@ -118,7 +118,7 @@
                                 </li>
                                 <li>
                                     <strong>Test Report:</strong>
-                                    <t t-out="object.upload_test_report"/>
+                                    <t t-out="object.test_report"/>
                                 </li>
 
                             </ul>

--- a/custom_addons/legal_compliance_management/models/x_legal_regulation.py
+++ b/custom_addons/legal_compliance_management/models/x_legal_regulation.py
@@ -9,7 +9,7 @@ class LegalRegulation(models.Model):
     description_lrs = fields.Text(string="Description of Legal Regulation Standards", store=True)
     classification_id = fields.Many2one("x.legal.classification", string="Classification of Legal Regulations", store=True)
     lr_number = fields.Char(string="LR S.No.")
-    upload_requirements = fields.Text(string="LR requirements")
+    lr_requirements = fields.Text(string="LR requirements")
     date = fields.Date(string="Date")
     version = fields.Char(string="Version")
     lr_year = fields.Char(string="Year")

--- a/custom_addons/legal_compliance_management/models/x_monitoring_measurement.py
+++ b/custom_addons/legal_compliance_management/models/x_monitoring_measurement.py
@@ -27,7 +27,7 @@ class MonitoringMeasurement(models.Model):
     company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company)
     lr_sno = fields.Char(related='legal_regulations_id.lr_number', string='OPEN LR S.No')
     lr_description = fields.Text(string='LR Description', related='legal_regulations_id.description_lrs')
-    lr_requirements = fields.Text(string='LR Requirements', related='legal_regulations_id.upload_requirements')
+    lr_requirements = fields.Text(string='LR Requirements', related='legal_regulations_id.lr_requirements')
     title_of_programme = fields.Text(string='Title of Programme', required=True)
     acceptance_criteria = fields.Text(string='Acceptance Criteria', required=True)
     risk_assessment_reference = fields.Char(string='Risk Assessment Reference')
@@ -101,7 +101,7 @@ class MonitoringMeasurement(models.Model):
         }
 
         # Update the context before sending the email
-        template = template.with_context(email_values).send_mail(self.id, force_send=True)
+        template.send_mail(self.id, force_send=True, email_values=email_values)
 
 
 
@@ -121,16 +121,17 @@ class ComplianceObligation(models.Model):
         [('in_house', 'In-house'),
          ('third_party', 'Third Party Agency')],
         string='Test Performed by', readonly=True, related='monitoring_measurement_id.test_performed_by')
-    date_time = fields.Datetime(string="Test Performed on", required=True, tracking=True)
+    test_performed_on = fields.Datetime(string="Test Performed on", tracking=True)
     test_result = fields.Selection(
         [('pass', 'Pass'),
          ('fail', 'Fail')],
         string='Test Result'
     )
 
-    upload_test_report = fields.Text(string='Test report')
+    test_report = fields.Text(string='Test report')
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string='Upload ', help='Attachment')
-
+    assign_responsibility_id = fields.Many2one('res.users', string='Assign To', related='monitoring_measurement_id.assign_responsibility',
+                                            domain="[('department_id', '=', select_department )]")
 
     def action_open_incident(self):
         return {
@@ -147,8 +148,32 @@ class ComplianceObligation(models.Model):
             }
         }
 
-    def send_notification(self):
-        mail_template = self.env.ref('legal_compliance_management.email_template_legal_compliance')
-        mail_template.send_mail(self.id, force_send=True)
+    def get_users_with_access_right(self, group_name):
+        group_id = self.env.ref(group_name)
 
-        return True
+        if group_id:
+            # Retrieve users who have the specified access right
+            users_with_access_right = self.env['res.users'].search([('groups_id', 'in', group_id.id)])
+            mail_list = []
+
+            for user in users_with_access_right:
+                mail_list.append(user.employee_id.work_email)
+            return mail_list
+        else:
+            return []
+
+    def send_notification(self):
+        hse_mail_list = self.get_users_with_access_right('aicomsy_base.access_hse_manager')
+        qa_qc_mail_list = self.get_users_with_access_right('aicomsy_base.access_qa_qc_manager')
+
+        managers_mail_list = hse_mail_list + qa_qc_mail_list
+
+        template = self.env.ref('legal_compliance_management.email_template_legal_compliance')
+        email_values = {
+            'email_to': ','.join(str(email) for email in managers_mail_list if isinstance(email, str))
+
+        }
+
+        # Update the context before sending the email
+        template.send_mail(self.id, force_send=True, email_values=email_values)
+

--- a/custom_addons/legal_compliance_management/models/x_monitoring_measurement.py
+++ b/custom_addons/legal_compliance_management/models/x_monitoring_measurement.py
@@ -132,7 +132,7 @@ class ComplianceObligation(models.Model):
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string='Upload ', help='Attachment')
     assign_responsibility_id = fields.Many2one('res.users', string='Assign To', related='monitoring_measurement_id.assign_responsibility',
                                             domain="[('department_id', '=', select_department )]")
-
+    is_assign = fields.Boolean(compute="_is_assign")
     def action_open_incident(self):
         return {
             'name': 'All Incident',
@@ -177,3 +177,5 @@ class ComplianceObligation(models.Model):
         # Update the context before sending the email
         template.send_mail(self.id, force_send=True, email_values=email_values)
 
+    def _is_assign(self):
+        self.is_assign = self.env.user == self.assign_responsibility_id

--- a/custom_addons/legal_compliance_management/views/legal_register_menu.xml
+++ b/custom_addons/legal_compliance_management/views/legal_register_menu.xml
@@ -3,14 +3,14 @@
 
 
     <menuitem id="legal_register_menu" name="Legal Compliance" groups="base.group_user">
-        <menuitem id="legal_register" name="Legal Register" sequence="1">
+        <menuitem id="legal_register" name="Legal Register" sequence="1" groups="aicomsy_base.access_hse_manager,aicomsy_base.access_qa_qc_manager">
             <menuitem id="legal_register_menu_action" action="id_act_server" sequence="1"/>
             <menuitem id="legal_register_tree_action" action="legal_register_action" sequence="2"/>
         </menuitem>
-        <menuitem id="legal_regulation" name="Legal Regulation Register (LR)" sequence="2">
+        <menuitem id="legal_regulation" name="Legal Regulation Register (LR)" sequence="2" groups="aicomsy_base.access_hse_manager,aicomsy_base.access_qa_qc_manager">
             <menuitem id="legal_regulation_menu_action" action="legal_regulation_action" sequence="1"/>
         </menuitem>
-        <menuitem id="monitoring_measurement" name="Monitoring and Measurement Programme" sequence="3">
+        <menuitem id="monitoring_measurement" name="Monitoring and Measurement Programme" sequence="3" groups="aicomsy_base.access_hse_manager,aicomsy_base.access_qa_qc_manager">
             <menuitem id="monitoring_measurement_menu_action" action="monitoring_measurement_action" sequence="1"/>
         </menuitem>
         <menuitem id="legal_compliance" name="Legal Compliance" sequence="4">

--- a/custom_addons/legal_compliance_management/views/x_legal_regulation_views.xml
+++ b/custom_addons/legal_compliance_management/views/x_legal_regulation_views.xml
@@ -28,7 +28,7 @@
                 <field name="company_id" optional="hide"/>
                 <field name="lr_number"/>
                 <field name="description_lrs"/>
-                <field name="upload_requirements"/>
+                <field name="lr_requirements"/>
                 <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}"/>
             </tree>
         </field>
@@ -42,7 +42,7 @@
                     <field name="company_id" optional="hide"/>
                     <field name="lr_number"/>
                     <field name="description_lrs"/>
-                    <field name="upload_requirements"/>
+                    <field name="lr_requirements"/>
                     <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}"/>
                 </group>
             </form>

--- a/custom_addons/legal_compliance_management/views/x_monitoring_measurement_views.xml
+++ b/custom_addons/legal_compliance_management/views/x_monitoring_measurement_views.xml
@@ -31,7 +31,8 @@
                         <field name="select_department" attrs="{'required': [('test_performed_by', '=', 'in_house')]}"/>
                     </group>
                     <group>
-                        <field name="assign_responsibility" attrs="{'required': [('test_performed_by', '=', 'in_house')]}"/>
+                        <field name="assign_responsibility"
+                               attrs="{'required': [('test_performed_by', '=', 'in_house')]}"/>
                     </group>
                 </group>
                 <button string="Send Notification" class="oe_highlight" type="object" name="send_notification"/>
@@ -45,7 +46,7 @@
         <field name="name">Legal Compliance</field>
         <field name="res_model">x.legal.compliance</field>
         <field name="view_mode">tree,form</field>
-         <field name="context">{'create': False, 'search_default_current_company':1}</field>
+        <field name="context">{'create': False, 'search_default_current_company':1}</field>
     </record>
 
     <record id="legal_compliance_search_view" model="ir.ui.view">
@@ -89,10 +90,12 @@
                     <field name="test_frequency"/>
                     <field name="test_performed_by"/>
                     <field name="assign_responsibility_id"/>
-                    <field name="test_performed_on" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}" required="True"/>
-                    <field name="test_result" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}"/>
-                    <field name="test_report" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}" required="True"/>
-                    <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}"/>
+                    <field name="test_performed_on" attrs="{'readonly': [('is_assign', '=', False)]}"/>
+                    <field name="test_result" attrs="{'readonly': [('is_assign', '=', False)]}"/>
+                    <field name="test_report" attrs="{'readonly': [('is_assign', '=', False)]}"/>
+                    <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}"
+                           attrs="{'readonly': [('is_assign', '=', False)]}"/>
+                    <field name="is_assign" invisible="True"/>
                 </group>
                 <group>
                     <button string="Incident" type="object" name="action_open_incident" class="oe_highlight"

--- a/custom_addons/legal_compliance_management/views/x_monitoring_measurement_views.xml
+++ b/custom_addons/legal_compliance_management/views/x_monitoring_measurement_views.xml
@@ -88,10 +88,11 @@
                     <field name="title_of_programme"/>
                     <field name="test_frequency"/>
                     <field name="test_performed_by"/>
-                    <field name="date_time"/>
-                    <field name="test_result"/>
-                    <field name="upload_test_report"/>
-                    <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}"/>
+                    <field name="assign_responsibility_id"/>
+                    <field name="test_performed_on" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}" required="True"/>
+                    <field name="test_result" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}"/>
+                    <field name="test_report" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}" required="True"/>
+                    <field name="attachment_ids" widget="many2many_binary" options="{'no_open': True}" attrs="{'readonly': [('assign_responsibility_id', '=', False)]}"/>
                 </group>
                 <group>
                     <button string="Incident" type="object" name="action_open_incident" class="oe_highlight"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In legal_register_menu.xml group access had been added, mail_template_data.xml,x_legal_regulation_views.xml,x_legal_regulation.py some field name had been changed, x_monitoring_measurement.py field name and send notification button access had been added, x_monitoring_measurement_views.xml button state had been added
Current behavior before PR: Field name had been changed compliance send notification have no access

Desired behavior after PR is merged: Compliance send notification  access had been added for hsc and qa/qc managers



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
